### PR TITLE
Fixup key in sublime-package.json

### DIFF
--- a/sublime-package.json
+++ b/sublime-package.json
@@ -6,13 +6,13 @@
           "/LSP-rust-analyzer.sublime-settings"
         ],
         "schema": {
-          "$id": "sublime://settings/rust-analyzer",
+          "$id": "sublime://settings/LSP-rust-analyzer",
           "allOf": [
             {
               "$ref": "sublime://settings/LSP-plugin-base"
             },
             {
-              "$ref": "sublime://settings/rust-analyzer#/definitions/PluginConfig"
+              "$ref": "sublime://settings/LSP-rust-analyzer#/definitions/PluginConfig"
             }
           ],
           "definitions": {
@@ -627,7 +627,7 @@
                 "LSP": {
                   "properties": {
                     "rust-analyzer": {
-                      "$ref": "sublime://settings/rust-analyzer#/definitions/PluginConfig"
+                      "$ref": "sublime://settings/LSP-rust-analyzer#/definitions/PluginConfig"
                     }
                   }
                 }

--- a/sublime-package.json
+++ b/sublime-package.json
@@ -6,13 +6,13 @@
           "/LSP-rust-analyzer.sublime-settings"
         ],
         "schema": {
-          "$id": "sublime://settings/LSP-rust-analyzer",
+          "$id": "sublime://settings/rust-analyzer",
           "allOf": [
             {
               "$ref": "sublime://settings/LSP-plugin-base"
             },
             {
-              "$ref": "sublime://settings/LSP-rust-analyzer#/definitions/PluginConfig"
+              "$ref": "sublime://settings/rust-analyzer#/definitions/PluginConfig"
             }
           ],
           "definitions": {
@@ -626,8 +626,8 @@
               "properties": {
                 "LSP": {
                   "properties": {
-                    "LSP-rust-analyzer": {
-                      "$ref": "sublime://settings/LSP-rust-analyzer#/definitions/PluginConfig"
+                    "rust-analyzer": {
+                      "$ref": "sublime://settings/rust-analyzer#/definitions/PluginConfig"
                     }
                   }
                 }


### PR DESCRIPTION
The tooling.py file has missing logic for client configs that don't start with LSP-. This makes LSP-json work in project overrides at least.