### PR TITLE
Add Reload Project command menu

### DIFF
--- a/LSP-rust-analyzer.sublime-commands
+++ b/LSP-rust-analyzer.sublime-commands
@@ -10,5 +10,9 @@
     {
         "caption": "LSP-rust-analyzer: Open Docs Under Cursor",
         "command": "rust_analyzer_open_docs"
+    },
+    {
+        "caption": "LSP-rust-analyzer: Reload Project",
+        "command": "rust_analyzer_reload_project"
     }
 ]

--- a/README.md
+++ b/README.md
@@ -43,3 +43,7 @@ This language server operates on views with the `source.rust` base scope.
 ### LSP-rust-analyzer: Open Docs Under Cursor
 
 Opens the URL to documentation for the symbol under the cursor, if available.
+
+### LSP-rust-analyzer: Reload Project
+
+Reloads the project metadata, i.e. runs `cargo metadata` again.

--- a/plugin.py
+++ b/plugin.py
@@ -120,6 +120,18 @@ class RustAnalyzerOpenDocsCommand(LspTextCommand):
         if url is not None:
             window.run_command("open_url", { "url": url })
 
+
+class RustAnalyzerReloadProject(LspTextCommand):
+    session_name = "rust-analyzer"
+
+    def run(self, edit: sublime.Edit) -> None:
+        session = self.session_by_name(self.session_name)
+        if session is None:
+            return
+
+        session.send_request(Request("rust-analyzer/reloadWorkspace"))
+
+
 def plugin_loaded() -> None:
     register_plugin(RustAnalyzer)
 


### PR DESCRIPTION
This is another LSP extension that rust-analyzer has which reloads the project metadata without restarting the server.