### PR TITLE
Add expand macro functionality

### DIFF
--- a/LSP-rust-analyzer.sublime-commands
+++ b/LSP-rust-analyzer.sublime-commands
@@ -14,5 +14,9 @@
     {
         "caption": "LSP-rust-analyzer: Reload Project",
         "command": "rust_analyzer_reload_project"
+    },
+    {
+        "caption": "LSP-rust-analyzer: Expand Macro Recursively",
+        "command": "rust_analyzer_expand_macro"
     }
 ]

--- a/README.md
+++ b/README.md
@@ -44,3 +44,7 @@ Opens the URL to documentation for the symbol under the cursor, if available.
 ### LSP-rust-analyzer: Reload Project
 
 Reloads the project metadata, i.e. runs `cargo metadata` again.
+
+### LSP-rust-analyzer: Expand Macro Recursively
+
+Shows the full macro expansion of the macro at current cursor.

--- a/plugin.py
+++ b/plugin.py
@@ -143,14 +143,17 @@ class RustAnalyzerExpandMacro(LspTextCommand):
         return super().is_enabled()
 
     def run(self, edit: sublime.Edit) -> None:
-        params = text_document_position_params(self.view, self.view.sel()[0].b)
         session = self.session_by_name(self.session_name)
         if session is None:
             return
 
+        params = text_document_position_params(self.view, self.view.sel()[0].b)
         session.send_request(Request("rust-analyzer/expandMacro", params), self.on_result)
 
-    def on_result(self, expanded_macro: Dict[str, str]) -> None:
+    def on_result(self, expanded_macro: Optional[Dict[str, str]]) -> None:
+        if expanded_macro is None:
+            return
+
         window = self.view.window()
         if window is None:
             return


### PR DESCRIPTION
Implements the custom [Expand Macro Recursively](https://rust-analyzer.github.io/manual.html#expand-macro-recursively) command palette menu item.