### PR TITLE
Fix settings to actually be respected

### DIFF
--- a/LSP-rust-analyzer.sublime-settings
+++ b/LSP-rust-analyzer.sublime-settings
@@ -9,159 +9,161 @@
 		"rust-analyzer.terminusAutoClose": false,
 		// Wether or not to spawn a panel at the bottom, or a new tab
 		"rust-analyzer.terminusUsePanel": false,
-
+	},
+	"initializationOptions": {
 		// Rust-Analyzer Server Settings
+		// Note that the rust-analyzer prefix in the official server manual is removed
 
 		//Whether to enforce the import granularity setting for all files. If set to false rust-analyzer will try to keep import styles consistent per file.
-		"rust-analyzer.assist.importEnforceGranularity": false,
+		"assist.importEnforceGranularity": false,
 		//How imports should be grouped into use statements.
-		"rust-analyzer.assist.importGranularity": "crate",
+		"assist.importGranularity": "crate",
 		//Group inserted imports by the [following order](https://rust-analyzer.github.io/manual.html#auto-import). Groups are separated by newlines.
-		"rust-analyzer.assist.importGroup": true,
+		"assist.importGroup": true,
 		//The path structure for newly inserted paths to use.
-		"rust-analyzer.assist.importPrefix": "plain",
+		"assist.importPrefix": "plain",
 		//Show function name and docs in parameter hints.
-		"rust-analyzer.callInfo.full": true,
+		"callInfo.full": true,
 		//Activate all available features (`--all-features`).
-		"rust-analyzer.cargo.allFeatures": false,
+		"cargo.allFeatures": false,
 		//Automatically refresh project info via `cargo metadata` on `Cargo.toml` changes.
-		"rust-analyzer.cargo.autoreload": true,
+		"cargo.autoreload": true,
 		//List of features to activate.
-		"rust-analyzer.cargo.features": [],
+		"cargo.features": [],
 		//Do not activate the `default` feature.
-		"rust-analyzer.cargo.noDefaultFeatures": false,
+		"cargo.noDefaultFeatures": false,
 		//Internal config for debugging, disables loading of sysroot crates.
-		"rust-analyzer.cargo.noSysroot": false,
+		"cargo.noSysroot": false,
 		//Run build scripts (`build.rs`) for more precise code analysis.
-		"rust-analyzer.cargo.runBuildScripts": true,
+		"cargo.runBuildScripts": true,
 		//Compilation target (target triple).
-		"rust-analyzer.cargo.target": null,
+		"cargo.target": null,
 		//Use `RUSTC_WRAPPER=rust-analyzer` when running build scripts to avoid compiling unnecessary things.
-		"rust-analyzer.cargo.useRustcWrapperForBuildScripts": true,
+		"cargo.useRustcWrapperForBuildScripts": true,
 		//Custom cargo runner extension ID.
-		"rust-analyzer.cargoRunner": null,
+		"cargoRunner": null,
 		//Check with all features (`--all-features`). Defaults to `#rust-analyzer.cargo.allFeatures#`.
-		"rust-analyzer.checkOnSave.allFeatures": null,
+		"checkOnSave.allFeatures": null,
 		//Check all targets and tests (`--all-targets`).
-		"rust-analyzer.checkOnSave.allTargets": true,
+		"checkOnSave.allTargets": true,
 		//Cargo command to use for `cargo check`.
-		"rust-analyzer.checkOnSave.command": "check",
+		"checkOnSave.command": "check",
 		//Run specified `cargo check` command for diagnostics on save.
-		"rust-analyzer.checkOnSave.enable": true,
+		"checkOnSave.enable": true,
 		//Extra arguments for `cargo check`.
-		"rust-analyzer.checkOnSave.extraArgs": [],
+		"checkOnSave.extraArgs": [],
 		//List of features to activate. Defaults to `#rust-analyzer.cargo.features#`.
-		"rust-analyzer.checkOnSave.features": null,
+		"checkOnSave.features": null,
 		//Do not activate the `default` feature.
-		"rust-analyzer.checkOnSave.noDefaultFeatures": null,
+		"checkOnSave.noDefaultFeatures": null,
 		//Advanced option, fully override the command rust-analyzer uses for checking. The command should include `--message-format=json` or similar option.
-		"rust-analyzer.checkOnSave.overrideCommand": null,
+		"checkOnSave.overrideCommand": null,
 		//Check for a specific target. Defaults to `#rust-analyzer.cargo.target#`.
-		"rust-analyzer.checkOnSave.target": null,
+		"checkOnSave.target": null,
 		//Whether to add argument snippets when completing functions. Only applies when `#rust-analyzer.completion.addCallParenthesis#` is set.
-		"rust-analyzer.completion.addCallArgumentSnippets": true,
+		"completion.addCallArgumentSnippets": true,
 		//Whether to add parenthesis when completing functions.
-		"rust-analyzer.completion.addCallParenthesis": true,
+		"completion.addCallParenthesis": true,
 		//Toggles the additional completions that automatically add imports when completed. Note that your client must specify the `additionalTextEdits` LSP client capability to truly have this feature enabled.
-		"rust-analyzer.completion.autoimport.enable": true,
+		"completion.autoimport.enable": true,
 		//Toggles the additional completions that automatically show method calls and field accesses with `self` prefixed to them when inside a method.
-		"rust-analyzer.completion.autoself.enable": true,
+		"completion.autoself.enable": true,
 		//Whether to show postfix snippets like `dbg`, `if`, `not`, etc.
-		"rust-analyzer.completion.postfix.enable": true,
+		"completion.postfix.enable": true,
 		//Preferred debug engine.
-		"rust-analyzer.debug.engine": "auto",
+		"debug.engine": "auto",
 		//Optional settings passed to the debug engine. Example: `{ "lldb": { "terminal":"external"} }`
-		"rust-analyzer.debug.engineSettings": {},
+		"debug.engineSettings": {},
 		//Whether to open up the `Debug Panel` on debugging start.
-		"rust-analyzer.debug.openDebugPane": false,
+		"debug.openDebugPane": false,
 		//Optional source file mappings passed to the debug engine.
-		"rust-analyzer.debug.sourceFileMap": {"/rustc/<id>": "${env:USERPROFILE}/.rustup/toolchains/<toolchain-id>/lib/rustlib/src/rust"},
+		"debug.sourceFileMap": {"/rustc/<id>": "${env:USERPROFILE}/.rustup/toolchains/<toolchain-id>/lib/rustlib/src/rust"},
 		//List of rust-analyzer diagnostics to disable.
-		"rust-analyzer.diagnostics.disabled": [],
+		"diagnostics.disabled": [],
 		//Whether to show native rust-analyzer diagnostics.
-		"rust-analyzer.diagnostics.enable": true,
+		"diagnostics.enable": true,
 		//Whether to show experimental rust-analyzer diagnostics that might have more false positives than usual.
-		"rust-analyzer.diagnostics.enableExperimental": true,
+		"diagnostics.enableExperimental": true,
 		//Map of prefixes to be substituted when parsing diagnostic file paths. This should be the reverse mapping of what is passed to `rustc` as `--remap-path-prefix`.
-		"rust-analyzer.diagnostics.remapPrefix": {},
+		"diagnostics.remapPrefix": {},
 		//List of warnings that should be displayed with hint severity.  The warnings will be indicated by faded text or three dots in code and will not show up in the `Problems Panel`.
-		"rust-analyzer.diagnostics.warningsAsHint": [],
+		"diagnostics.warningsAsHint": [],
 		//List of warnings that should be displayed with info severity.  The warnings will be indicated by a blue squiggly underline in code and a blue icon in the `Problems Panel`.
-		"rust-analyzer.diagnostics.warningsAsInfo": [],
+		"diagnostics.warningsAsInfo": [],
 		//Expand attribute macros.
-		"rust-analyzer.experimental.procAttrMacros": false,
+		"experimental.procAttrMacros": false,
 		//These directories will be ignored by rust-analyzer.
-		"rust-analyzer.files.excludeDirs": [],
+		"files.excludeDirs": [],
 		//Controls file watching implementation.
-		"rust-analyzer.files.watcher": "client",
+		"files.watcher": "client",
 		//Use semantic tokens for strings.  In some editors (e.g. vscode) semantic tokens override other highlighting grammars. By disabling semantic tokens for strings, other grammars can be used to highlight their contents.
-		"rust-analyzer.highlighting.strings": true,
+		"highlighting.strings": true,
 		//Whether to show `Debug` action. Only applies when `#rust-analyzer.hoverActions.enable#` is set.
-		"rust-analyzer.hoverActions.debug": true,
+		"hoverActions.debug": true,
 		//Whether to show HoverActions in Rust files.
-		"rust-analyzer.hoverActions.enable": true,
+		"hoverActions.enable": true,
 		//Whether to show `Go to Type Definition` action. Only applies when `#rust-analyzer.hoverActions.enable#` is set.
-		"rust-analyzer.hoverActions.gotoTypeDef": true,
+		"hoverActions.gotoTypeDef": true,
 		//Whether to show `Implementations` action. Only applies when `#rust-analyzer.hoverActions.enable#` is set.
-		"rust-analyzer.hoverActions.implementations": true,
+		"hoverActions.implementations": true,
 		//Use markdown syntax for links in hover.
-		"rust-analyzer.hoverActions.linksInHover": true,
+		"hoverActions.linksInHover": true,
 		//Whether to show `References` action. Only applies when `#rust-analyzer.hoverActions.enable#` is set.
-		"rust-analyzer.hoverActions.references": false,
+		"hoverActions.references": false,
 		//Whether to show `Run` action. Only applies when `#rust-analyzer.hoverActions.enable#` is set.
-		"rust-analyzer.hoverActions.run": true,
+		"hoverActions.run": true,
 		//Whether to show inlay type hints for method chains.
-		"rust-analyzer.inlayHints.chainingHints": true,
+		"inlayHints.chainingHints": true,
 		//Whether to show inlay hints.
-		"rust-analyzer.inlayHints.enable": true,
+		"inlayHints.enable": true,
 		//Maximum length for inlay hints. Set to null to have an unlimited length.
-		"rust-analyzer.inlayHints.maxLength": 25,
+		"inlayHints.maxLength": 25,
 		//Whether to show function parameter name inlay hints at the call site.
-		"rust-analyzer.inlayHints.parameterHints": true,
+		"inlayHints.parameterHints": true,
 		//Whether inlay hints font size should be smaller than editor's font size.
-		"rust-analyzer.inlayHints.smallerHints": true,
+		"inlayHints.smallerHints": true,
 		//Whether to show inlay type hints for variables.
-		"rust-analyzer.inlayHints.typeHints": true,
+		"inlayHints.typeHints": true,
 		//Whether to show `Debug` lens. Only applies when `#rust-analyzer.lens.enable#` is set.
-		"rust-analyzer.lens.debug": true,
+		"lens.debug": true,
 		//Whether to show CodeLens in Rust files.
-		"rust-analyzer.lens.enable": true,
+		"lens.enable": true,
 		//Whether to show `Implementations` lens. Only applies when `#rust-analyzer.lens.enable#` is set.
-		"rust-analyzer.lens.implementations": true,
+		"lens.implementations": true,
 		//Whether to show `Method References` lens. Only applies when `#rust-analyzer.lens.enable#` is set.
-		"rust-analyzer.lens.methodReferences": false,
+		"lens.methodReferences": false,
 		//Whether to show `References` lens. Only applies when `#rust-analyzer.lens.enable#` is set.
-		"rust-analyzer.lens.references": false,
+		"lens.references": false,
 		//Whether to show `Run` lens. Only applies when `#rust-analyzer.lens.enable#` is set.
-		"rust-analyzer.lens.run": true,
+		"lens.run": true,
 		//Disable project auto-discovery in favor of explicitly specified set of projects.  Elements must be paths pointing to `Cargo.toml`, `rust-project.json`, or JSON objects in `rust-project.json` format.
-		"rust-analyzer.linkedProjects": [],
+		"linkedProjects": [],
 		//Number of syntax trees rust-analyzer keeps in memory. Defaults to 128.
-		"rust-analyzer.lruCapacity": null,
+		"lruCapacity": null,
 		//Whether to show `can't find Cargo.toml` error message.
-		"rust-analyzer.notifications.cargoTomlNotFound": true,
+		"notifications.cargoTomlNotFound": true,
 		//Enable support for procedural macros, implies `#rust-analyzer.cargo.runBuildScripts#`.
-		"rust-analyzer.procMacro.enable": true,
+		"procMacro.enable": true,
 		//Internal config, path to proc-macro server executable (typically, this is rust-analyzer itself, but we override this in tests).
-		"rust-analyzer.procMacro.server": null,
+		"procMacro.server": null,
 		//Environment variables passed to the runnable launched using `Test` or `Debug` lens or `rust-analyzer.run` command.
-		"rust-analyzer.runnableEnv": null,
+		"runnableEnv": null,
 		//Additional arguments to be passed to cargo for runnables such as tests or binaries. For example, it may be `--release`.
-		"rust-analyzer.runnables.cargoExtraArgs": [],
+		"runnables.cargoExtraArgs": [],
 		//Command to be executed instead of 'cargo' for runnables.
-		"rust-analyzer.runnables.overrideCargo": null,
+		"runnables.overrideCargo": null,
 		//Path to the Cargo.toml of the rust compiler workspace, for usage in rustc_private projects, or "discover" to try to automatically find it.  Any project which uses rust-analyzer with the rustcPrivate crates must set `[package.metadata.rust-analyzer] rustc_private=true` to use it.  This option is not reloaded automatically; you must restart rust-analyzer for it to take effect.
-		"rust-analyzer.rustcSource": null,
+		"rustcSource": null,
 		//Enables the use of rustfmt's unstable range formatting command for the `textDocument/rangeFormatting` request. The rustfmt option is unstable and only available on a nightly build.
-		"rust-analyzer.rustfmt.enableRangeFormatting": false,
+		"rustfmt.enableRangeFormatting": false,
 		//Additional arguments to `rustfmt`.
-		"rust-analyzer.rustfmt.extraArgs": [],
+		"rustfmt.extraArgs": [],
 		//Advanced option, fully override the command rust-analyzer uses for formatting.
-		"rust-analyzer.rustfmt.overrideCommand": null,
+		"rustfmt.overrideCommand": null,
 		//Workspace symbol search kind.
-		"rust-analyzer.workspace.symbol.search.kind": "only_types",
+		"workspace.symbol.search.kind": "only_types",
 		//Workspace symbol search scope.
-		"rust-analyzer.workspace.symbol.search.scope": "workspace"
+		"workspace.symbol.search.scope": "workspace"
 	},
 	"experimental_capabilities": {
 		// empty for now

--- a/sublime-package.json
+++ b/sublime-package.json
@@ -31,12 +31,17 @@
                       "description": "Wether or not to spawn a panel at the bottom, or a new tab.",
                       "type": "boolean"
                     },
-                    "rust-analyzer.assist.importEnforceGranularity": {
+                  },
+                },
+                "initializationOptions": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "assist.importEnforceGranularity": {
                       "default": false,
                       "markdownDescription": "Whether to enforce the import granularity setting for all files. If set to false rust-analyzer will try to keep import styles consistent per file.",
                       "type": "boolean"
                     },
-                    "rust-analyzer.assist.importGranularity": {
+                    "assist.importGranularity": {
                       "default": "crate",
                       "enum": [
                         "preserve",
@@ -53,12 +58,12 @@
                       "markdownDescription": "How imports should be grouped into use statements.",
                       "type": "string"
                     },
-                    "rust-analyzer.assist.importGroup": {
+                    "assist.importGroup": {
                       "default": true,
                       "markdownDescription": "Group inserted imports by the [following order](https://rust-analyzer.github.io/manual.html#auto-import). Groups are separated by newlines.",
                       "type": "boolean"
                     },
-                    "rust-analyzer.assist.importPrefix": {
+                    "assist.importPrefix": {
                       "default": "plain",
                       "enum": [
                         "plain",
@@ -73,22 +78,22 @@
                       "markdownDescription": "The path structure for newly inserted paths to use.",
                       "type": "string"
                     },
-                    "rust-analyzer.callInfo.full": {
+                    "callInfo.full": {
                       "default": true,
                       "markdownDescription": "Show function name and docs in parameter hints.",
                       "type": "boolean"
                     },
-                    "rust-analyzer.cargo.allFeatures": {
+                    "cargo.allFeatures": {
                       "default": false,
                       "markdownDescription": "Activate all available features (`--all-features`).",
                       "type": "boolean"
                     },
-                    "rust-analyzer.cargo.autoreload": {
+                    "cargo.autoreload": {
                       "default": true,
                       "markdownDescription": "Automatically refresh project info via `cargo metadata` on\n`Cargo.toml` changes.",
                       "type": "boolean"
                     },
-                    "rust-analyzer.cargo.features": {
+                    "cargo.features": {
                       "default": [],
                       "items": {
                         "type": "string"
@@ -96,22 +101,22 @@
                       "markdownDescription": "List of features to activate.",
                       "type": "array"
                     },
-                    "rust-analyzer.cargo.noDefaultFeatures": {
+                    "cargo.noDefaultFeatures": {
                       "default": false,
                       "markdownDescription": "Do not activate the `default` feature.",
                       "type": "boolean"
                     },
-                    "rust-analyzer.cargo.noSysroot": {
+                    "cargo.noSysroot": {
                       "default": false,
                       "markdownDescription": "Internal config for debugging, disables loading of sysroot crates.",
                       "type": "boolean"
                     },
-                    "rust-analyzer.cargo.runBuildScripts": {
+                    "cargo.runBuildScripts": {
                       "default": true,
                       "markdownDescription": "Run build scripts (`build.rs`) for more precise code analysis.",
                       "type": "boolean"
                     },
-                    "rust-analyzer.cargo.target": {
+                    "cargo.target": {
                       "default": null,
                       "markdownDescription": "Compilation target (target triple).",
                       "type": [
@@ -119,12 +124,12 @@
                         "string"
                       ]
                     },
-                    "rust-analyzer.cargo.useRustcWrapperForBuildScripts": {
+                    "cargo.useRustcWrapperForBuildScripts": {
                       "default": true,
                       "markdownDescription": "Use `RUSTC_WRAPPER=rust-analyzer` when running build scripts to\navoid compiling unnecessary things.",
                       "type": "boolean"
                     },
-                    "rust-analyzer.cargoRunner": {
+                    "cargoRunner": {
                       "default": null,
                       "description": "Custom cargo runner extension ID.",
                       "type": [
@@ -132,7 +137,7 @@
                         "string"
                       ]
                     },
-                    "rust-analyzer.checkOnSave.allFeatures": {
+                    "checkOnSave.allFeatures": {
                       "default": null,
                       "markdownDescription": "Check with all features (`--all-features`).\nDefaults to `#rust-analyzer.cargo.allFeatures#`.",
                       "type": [
@@ -140,22 +145,22 @@
                         "boolean"
                       ]
                     },
-                    "rust-analyzer.checkOnSave.allTargets": {
+                    "checkOnSave.allTargets": {
                       "default": true,
                       "markdownDescription": "Check all targets and tests (`--all-targets`).",
                       "type": "boolean"
                     },
-                    "rust-analyzer.checkOnSave.command": {
+                    "checkOnSave.command": {
                       "default": "check",
                       "markdownDescription": "Cargo command to use for `cargo check`.",
                       "type": "string"
                     },
-                    "rust-analyzer.checkOnSave.enable": {
+                    "checkOnSave.enable": {
                       "default": true,
                       "markdownDescription": "Run specified `cargo check` command for diagnostics on save.",
                       "type": "boolean"
                     },
-                    "rust-analyzer.checkOnSave.extraArgs": {
+                    "checkOnSave.extraArgs": {
                       "default": [],
                       "items": {
                         "type": "string"
@@ -163,7 +168,7 @@
                       "markdownDescription": "Extra arguments for `cargo check`.",
                       "type": "array"
                     },
-                    "rust-analyzer.checkOnSave.features": {
+                    "checkOnSave.features": {
                       "default": null,
                       "items": {
                         "type": "string"
@@ -174,7 +179,7 @@
                         "array"
                       ]
                     },
-                    "rust-analyzer.checkOnSave.noDefaultFeatures": {
+                    "checkOnSave.noDefaultFeatures": {
                       "default": null,
                       "markdownDescription": "Do not activate the `default` feature.",
                       "type": [
@@ -182,7 +187,7 @@
                         "boolean"
                       ]
                     },
-                    "rust-analyzer.checkOnSave.overrideCommand": {
+                    "checkOnSave.overrideCommand": {
                       "default": null,
                       "items": {
                         "type": "string"
@@ -193,7 +198,7 @@
                         "array"
                       ]
                     },
-                    "rust-analyzer.checkOnSave.target": {
+                    "checkOnSave.target": {
                       "default": null,
                       "markdownDescription": "Check for a specific target. Defaults to\n`#rust-analyzer.cargo.target#`.",
                       "type": [
@@ -201,32 +206,32 @@
                         "string"
                       ]
                     },
-                    "rust-analyzer.completion.addCallArgumentSnippets": {
+                    "completion.addCallArgumentSnippets": {
                       "default": true,
                       "markdownDescription": "Whether to add argument snippets when completing functions.\nOnly applies when `#rust-analyzer.completion.addCallParenthesis#` is set.",
                       "type": "boolean"
                     },
-                    "rust-analyzer.completion.addCallParenthesis": {
+                    "completion.addCallParenthesis": {
                       "default": true,
                       "markdownDescription": "Whether to add parenthesis when completing functions.",
                       "type": "boolean"
                     },
-                    "rust-analyzer.completion.autoimport.enable": {
+                    "completion.autoimport.enable": {
                       "default": true,
                       "markdownDescription": "Toggles the additional completions that automatically add imports when completed.\nNote that your client must specify the `additionalTextEdits` LSP client capability to truly have this feature enabled.",
                       "type": "boolean"
                     },
-                    "rust-analyzer.completion.autoself.enable": {
+                    "completion.autoself.enable": {
                       "default": true,
                       "markdownDescription": "Toggles the additional completions that automatically show method calls and field accesses\nwith `self` prefixed to them when inside a method.",
                       "type": "boolean"
                     },
-                    "rust-analyzer.completion.postfix.enable": {
+                    "completion.postfix.enable": {
                       "default": true,
                       "markdownDescription": "Whether to show postfix snippets like `dbg`, `if`, `not`, etc.",
                       "type": "boolean"
                     },
-                    "rust-analyzer.debug.engine": {
+                    "debug.engine": {
                       "default": "auto",
                       "description": "Preferred debug engine.",
                       "enum": [
@@ -241,17 +246,17 @@
                       ],
                       "type": "string"
                     },
-                    "rust-analyzer.debug.engineSettings": {
+                    "debug.engineSettings": {
                       "default": {},
                       "markdownDescription": "Optional settings passed to the debug engine. Example: `{ \"lldb\": { \"terminal\":\"external\"} }`",
                       "type": "object"
                     },
-                    "rust-analyzer.debug.openDebugPane": {
+                    "debug.openDebugPane": {
                       "default": false,
                       "markdownDescription": "Whether to open up the `Debug Panel` on debugging start.",
                       "type": "boolean"
                     },
-                    "rust-analyzer.debug.sourceFileMap": {
+                    "debug.sourceFileMap": {
                       "const": "auto",
                       "default": {
                         "/rustc/<id>": "${env:USERPROFILE}/.rustup/toolchains/<toolchain-id>/lib/rustlib/src/rust"
@@ -262,7 +267,7 @@
                         "string"
                       ]
                     },
-                    "rust-analyzer.diagnostics.disabled": {
+                    "diagnostics.disabled": {
                       "default": [],
                       "items": {
                         "type": "string"
@@ -271,22 +276,22 @@
                       "type": "array",
                       "uniqueItems": true
                     },
-                    "rust-analyzer.diagnostics.enable": {
+                    "diagnostics.enable": {
                       "default": true,
                       "markdownDescription": "Whether to show native rust-analyzer diagnostics.",
                       "type": "boolean"
                     },
-                    "rust-analyzer.diagnostics.enableExperimental": {
+                    "diagnostics.enableExperimental": {
                       "default": true,
                       "markdownDescription": "Whether to show experimental rust-analyzer diagnostics that might\nhave more false positives than usual.",
                       "type": "boolean"
                     },
-                    "rust-analyzer.diagnostics.remapPrefix": {
+                    "diagnostics.remapPrefix": {
                       "default": {},
                       "markdownDescription": "Map of prefixes to be substituted when parsing diagnostic file paths.\nThis should be the reverse mapping of what is passed to `rustc` as `--remap-path-prefix`.",
                       "type": "object"
                     },
-                    "rust-analyzer.diagnostics.warningsAsHint": {
+                    "diagnostics.warningsAsHint": {
                       "default": [],
                       "items": {
                         "type": "string"
@@ -294,7 +299,7 @@
                       "markdownDescription": "List of warnings that should be displayed with hint severity.\n\nThe warnings will be indicated by faded text or three dots in code\nand will not show up in the `Problems Panel`.",
                       "type": "array"
                     },
-                    "rust-analyzer.diagnostics.warningsAsInfo": {
+                    "diagnostics.warningsAsInfo": {
                       "default": [],
                       "items": {
                         "type": "string"
@@ -302,12 +307,12 @@
                       "markdownDescription": "List of warnings that should be displayed with info severity.\n\nThe warnings will be indicated by a blue squiggly underline in code\nand a blue icon in the `Problems Panel`.",
                       "type": "array"
                     },
-                    "rust-analyzer.experimental.procAttrMacros": {
+                    "experimental.procAttrMacros": {
                       "default": false,
                       "markdownDescription": "Expand attribute macros.",
                       "type": "boolean"
                     },
-                    "rust-analyzer.files.excludeDirs": {
+                    "files.excludeDirs": {
                       "default": [],
                       "items": {
                         "type": "string"
@@ -315,62 +320,62 @@
                       "markdownDescription": "These directories will be ignored by rust-analyzer.",
                       "type": "array"
                     },
-                    "rust-analyzer.files.watcher": {
+                    "files.watcher": {
                       "default": "client",
                       "markdownDescription": "Controls file watching implementation.",
                       "type": "string"
                     },
-                    "rust-analyzer.highlighting.strings": {
+                    "highlighting.strings": {
                       "default": true,
                       "markdownDescription": "Use semantic tokens for strings.\n\nIn some editors (e.g. vscode) semantic tokens override other highlighting grammars.\nBy disabling semantic tokens for strings, other grammars can be used to highlight\ntheir contents.",
                       "type": "boolean"
                     },
-                    "rust-analyzer.hoverActions.debug": {
+                    "hoverActions.debug": {
                       "default": true,
                       "markdownDescription": "Whether to show `Debug` action. Only applies when\n`#rust-analyzer.hoverActions.enable#` is set.",
                       "type": "boolean"
                     },
-                    "rust-analyzer.hoverActions.enable": {
+                    "hoverActions.enable": {
                       "default": true,
                       "markdownDescription": "Whether to show HoverActions in Rust files.",
                       "type": "boolean"
                     },
-                    "rust-analyzer.hoverActions.gotoTypeDef": {
+                    "hoverActions.gotoTypeDef": {
                       "default": true,
                       "markdownDescription": "Whether to show `Go to Type Definition` action. Only applies when\n`#rust-analyzer.hoverActions.enable#` is set.",
                       "type": "boolean"
                     },
-                    "rust-analyzer.hoverActions.implementations": {
+                    "hoverActions.implementations": {
                       "default": true,
                       "markdownDescription": "Whether to show `Implementations` action. Only applies when\n`#rust-analyzer.hoverActions.enable#` is set.",
                       "type": "boolean"
                     },
-                    "rust-analyzer.hoverActions.linksInHover": {
+                    "hoverActions.linksInHover": {
                       "default": true,
                       "markdownDescription": "Use markdown syntax for links in hover.",
                       "type": "boolean"
                     },
-                    "rust-analyzer.hoverActions.references": {
+                    "hoverActions.references": {
                       "default": false,
                       "markdownDescription": "Whether to show `References` action. Only applies when\n`#rust-analyzer.hoverActions.enable#` is set.",
                       "type": "boolean"
                     },
-                    "rust-analyzer.hoverActions.run": {
+                    "hoverActions.run": {
                       "default": true,
                       "markdownDescription": "Whether to show `Run` action. Only applies when\n`#rust-analyzer.hoverActions.enable#` is set.",
                       "type": "boolean"
                     },
-                    "rust-analyzer.inlayHints.chainingHints": {
+                    "inlayHints.chainingHints": {
                       "default": true,
                       "markdownDescription": "Whether to show inlay type hints for method chains.",
                       "type": "boolean"
                     },
-                    "rust-analyzer.inlayHints.enable": {
+                    "inlayHints.enable": {
                       "default": true,
                       "description": "Whether to show inlay hints.",
                       "type": "boolean"
                     },
-                    "rust-analyzer.inlayHints.maxLength": {
+                    "inlayHints.maxLength": {
                       "default": 25,
                       "markdownDescription": "Maximum length for inlay hints. Set to null to have an unlimited length.",
                       "minimum": 0,
@@ -379,52 +384,52 @@
                         "integer"
                       ]
                     },
-                    "rust-analyzer.inlayHints.parameterHints": {
+                    "inlayHints.parameterHints": {
                       "default": true,
                       "markdownDescription": "Whether to show function parameter name inlay hints at the call\nsite.",
                       "type": "boolean"
                     },
-                    "rust-analyzer.inlayHints.smallerHints": {
+                    "inlayHints.smallerHints": {
                       "default": true,
                       "description": "Whether inlay hints font size should be smaller than editor's font size.",
                       "type": "boolean"
                     },
-                    "rust-analyzer.inlayHints.typeHints": {
+                    "inlayHints.typeHints": {
                       "default": true,
                       "markdownDescription": "Whether to show inlay type hints for variables.",
                       "type": "boolean"
                     },
-                    "rust-analyzer.lens.debug": {
+                    "lens.debug": {
                       "default": true,
                       "markdownDescription": "Whether to show `Debug` lens. Only applies when\n`#rust-analyzer.lens.enable#` is set.",
                       "type": "boolean"
                     },
-                    "rust-analyzer.lens.enable": {
+                    "lens.enable": {
                       "default": true,
                       "markdownDescription": "Whether to show CodeLens in Rust files.",
                       "type": "boolean"
                     },
-                    "rust-analyzer.lens.implementations": {
+                    "lens.implementations": {
                       "default": true,
                       "markdownDescription": "Whether to show `Implementations` lens. Only applies when\n`#rust-analyzer.lens.enable#` is set.",
                       "type": "boolean"
                     },
-                    "rust-analyzer.lens.methodReferences": {
+                    "lens.methodReferences": {
                       "default": false,
                       "markdownDescription": "Whether to show `Method References` lens. Only applies when\n`#rust-analyzer.lens.enable#` is set.",
                       "type": "boolean"
                     },
-                    "rust-analyzer.lens.references": {
+                    "lens.references": {
                       "default": false,
                       "markdownDescription": "Whether to show `References` lens. Only applies when\n`#rust-analyzer.lens.enable#` is set.",
                       "type": "boolean"
                     },
-                    "rust-analyzer.lens.run": {
+                    "lens.run": {
                       "default": true,
                       "markdownDescription": "Whether to show `Run` lens. Only applies when\n`#rust-analyzer.lens.enable#` is set.",
                       "type": "boolean"
                     },
-                    "rust-analyzer.linkedProjects": {
+                    "linkedProjects": {
                       "default": [],
                       "items": {
                         "type": [
@@ -435,7 +440,7 @@
                       "markdownDescription": "Disable project auto-discovery in favor of explicitly specified set\nof projects.\n\nElements must be paths pointing to `Cargo.toml`,\n`rust-project.json`, or JSON objects in `rust-project.json` format.",
                       "type": "array"
                     },
-                    "rust-analyzer.lruCapacity": {
+                    "lruCapacity": {
                       "default": null,
                       "markdownDescription": "Number of syntax trees rust-analyzer keeps in memory. Defaults to 128.",
                       "minimum": 0,
@@ -444,17 +449,17 @@
                         "integer"
                       ]
                     },
-                    "rust-analyzer.notifications.cargoTomlNotFound": {
+                    "notifications.cargoTomlNotFound": {
                       "default": true,
                       "markdownDescription": "Whether to show `can't find Cargo.toml` error message.",
                       "type": "boolean"
                     },
-                    "rust-analyzer.procMacro.enable": {
+                    "procMacro.enable": {
                       "default": true,
                       "markdownDescription": "Enable support for procedural macros, implies `#rust-analyzer.cargo.runBuildScripts#`.",
                       "type": "boolean"
                     },
-                    "rust-analyzer.procMacro.server": {
+                    "procMacro.server": {
                       "default": null,
                       "markdownDescription": "Internal config, path to proc-macro server executable (typically,\nthis is rust-analyzer itself, but we override this in tests).",
                       "type": [
@@ -462,7 +467,7 @@
                         "string"
                       ]
                     },
-                    "rust-analyzer.runnableEnv": {
+                    "runnableEnv": {
                       "anyOf": [
                         {
                           "type": "null"
@@ -491,7 +496,7 @@
                       "default": null,
                       "markdownDescription": "Environment variables passed to the runnable launched using `Test` or `Debug` lens or `rust-analyzer.run` command."
                     },
-                    "rust-analyzer.runnables.cargoExtraArgs": {
+                    "runnables.cargoExtraArgs": {
                       "default": [],
                       "items": {
                         "type": "string"
@@ -499,7 +504,7 @@
                       "markdownDescription": "Additional arguments to be passed to cargo for runnables such as\ntests or binaries. For example, it may be `--release`.",
                       "type": "array"
                     },
-                    "rust-analyzer.runnables.overrideCargo": {
+                    "runnables.overrideCargo": {
                       "default": null,
                       "markdownDescription": "Command to be executed instead of 'cargo' for runnables.",
                       "type": [
@@ -507,7 +512,7 @@
                         "string"
                       ]
                     },
-                    "rust-analyzer.rustcSource": {
+                    "rustcSource": {
                       "default": null,
                       "markdownDescription": "Path to the Cargo.toml of the rust compiler workspace, for usage in rustc_private\nprojects, or \"discover\" to try to automatically find it.\n\nAny project which uses rust-analyzer with the rustcPrivate\ncrates must set `[package.metadata.rust-analyzer] rustc_private=true` to use it.\n\nThis option is not reloaded automatically; you must restart rust-analyzer for it to take effect.",
                       "type": [
@@ -515,12 +520,12 @@
                         "string"
                       ]
                     },
-                    "rust-analyzer.rustfmt.enableRangeFormatting": {
+                    "rustfmt.enableRangeFormatting": {
                       "default": false,
                       "markdownDescription": "Enables the use of rustfmt's unstable range formatting command for the\n`textDocument/rangeFormatting` request. The rustfmt option is unstable and only\navailable on a nightly build.",
                       "type": "boolean"
                     },
-                    "rust-analyzer.rustfmt.extraArgs": {
+                    "rustfmt.extraArgs": {
                       "default": [],
                       "items": {
                         "type": "string"
@@ -528,7 +533,7 @@
                       "markdownDescription": "Additional arguments to `rustfmt`.",
                       "type": "array"
                     },
-                    "rust-analyzer.rustfmt.overrideCommand": {
+                    "rustfmt.overrideCommand": {
                       "default": null,
                       "items": {
                         "type": "string"
@@ -539,7 +544,7 @@
                         "array"
                       ]
                     },
-                    "rust-analyzer.workspace.symbol.search.kind": {
+                    "workspace.symbol.search.kind": {
                       "default": "only_types",
                       "enum": [
                         "only_types",
@@ -552,7 +557,7 @@
                       "markdownDescription": "Workspace symbol search kind.",
                       "type": "string"
                     },
-                    "rust-analyzer.workspace.symbol.search.scope": {
+                    "workspace.symbol.search.scope": {
                       "default": "workspace",
                       "enum": [
                         "workspace",


### PR DESCRIPTION
The rust-analyzer binary expects these settings to be part of the LSP [`initializationOptions`](https://rust-analyzer.github.io/manual.html#configuration) rather than in the settings key. However, since the expected format doesn't expect a "rust-analyzer." prefix those have been removed as well to make our lives easier.