### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 test.py
 LSP/
+*.sublime-workspace
+*.sublime-project


### PR DESCRIPTION
These project files are usually dependent on the contributor and they just clutter the work tree.