### PR TITLE
Add option to use system provided rust-analyzer

### DIFF
--- a/LSP-rust-analyzer.sublime-settings
+++ b/LSP-rust-analyzer.sublime-settings
@@ -1,10 +1,12 @@
 {
 	"selector": "source.rust",
-	"command": ["${storage_path}/LSP-rust-analyzer/rust-analyzer"],
+	"command": ["${rust_analyzer_binary_path}"],
 	"settings": {
 
 		// Settings Not Related to rust-analyzer Server
 
+		// Wether to download the rust-analyzer binary or use the system provided binary
+		"rust-analyzer.useSystemBin": false,
 		// Wether or not to automatically close terminus panel/tab upon completion.
 		"rust-analyzer.terminusAutoClose": false,
 		// Wether or not to spawn a panel at the bottom, or a new tab

--- a/README.md
+++ b/README.md
@@ -37,7 +37,9 @@ This language server operates on views with the `source.rust` base scope.
 
 ## Installation Location
 
-The server binary is automatically downloaded to `$CACHE/Package Storage/LSP-rust-analyzer`.
+If the variable `rust-analyzer.useSystemBin` is `false` (the default), the server binary is automatically downloaded to `$CACHE/Package Storage/LSP-rust-analyzer`.
+
+Otherwise, the `rust-analyzer` binary installed in your system is used.
 
 ## Custom Command Palette Commands
 

--- a/plugin.py
+++ b/plugin.py
@@ -217,7 +217,18 @@ class RustAnalyzer(AbstractPlugin):
             return fp.read()
 
     @classmethod
+    def additional_variables(cls) -> Optional[Dict[str, str]]:
+        if sublime.load_settings('LSP-rust-analyzer.sublime-settings').get("settings", {}).get("rust-analyzer.useSystemBin"):
+            analyzer_bin_path = shutil.which("rust-analyzer") or shutil.which("rust-analyzer.exe") # type: Optional[str]
+            return { "rust_analyzer_binary_path": analyzer_bin_path }
+
+        return { "rust_analyzer_binary_path": cls.basedir() + "/rust-analyzer" }
+
+    @classmethod
     def needs_update_or_installation(cls) -> bool:
+        if sublime.load_settings('LSP-rust-analyzer.sublime-settings').get("settings", {}).get("rust-analyzer.useSystemBin"):
+            return False
+
         try:
             return cls.server_version() != cls.current_server_version()
         except OSError:


### PR DESCRIPTION
Hi :wave: 

In this PR, I've changed the `command` setting to use a variable via template string substitution, which is set via `additional_variables` [LSP class method](https://github.com/sublimelsp/LSP/blob/f83cb8654be9fa1bb07efa5bfc89924020a62324/plugin/core/sessions.py#L711-L716).

I've also added a new setting, `rust-analyzer.useSystemBin`, that controls the install behavior and the value of `command`.

If the variable is `false` (default), then the plugin should work as it does currently:
    - The `rust_analyzer_binary_path` variable will point to `<cache_path>/Package Storage/LSP-rust-analyzer/rust-analyzer`
    - The binary will be downloaded, versions will be compared, etc.

If the variable is `true`:
    - The `rust_analyzer_binary_path` variable will point to the result of the `shutil` check (e.g. `/usr/bin/rust-analyzer` on my Linux machine).
    - The `needs_update_or_installation` check will return `false` and no downloads/version checks will be done.

**How I tested it:**
    - Just copy my git version to the packages directory and open a Rust source file. Result: `rust-analyzer` was downloaded and ran from the path described above (I'm checking this using the `ps` command on Linux).
    - Remove the downloaded packages, then do the same as above, but change the value of `rust-analyzer.useSystemBin` to `true`. Result: no packages were downloaded, `rust-analyzer` ran from my system's install path.
    - Return the variable to the default value (`false`) and override it to `false` using a User config file. Result: same as item 1.
    - Remove the downloaded Packages, then override the variable to `true` using a User config file. Result: same as item 2.

**What I didn't test:** Windows, MacOS, Linux Flatpak, Linux Snap (two different packaging systems for Linux). As far as I know, if someone tries to do this on Flatpak, the check will never find the system's `rust-analyzer` binary because of filesystem sandboxing, but this can be worked around by Flatpak permissions, etc (i.e. this is not a problem related to this particular plugin).

**Other comments:** I do the conditional check twice, on `additional_variables` and `needs_update_or_installation`. I couldn't find a way to get the result of `additional_variables` and check against it instead.

My original implementation just used the `which` check to decide if the binary should be downloaded or not. Later, I decided to add a config option because some people may want to have a system binary for some cases, but use the plugin-downloaded binary with Sublime :shrug: 

I tried to add a `sublime.status_message` indicating which binary was being used, but sometimes the message was replaced so fast (with `rust-analyzer`'s output) that I decided to remove it.

Finally, this may have impacts in case of a newer/older system `rust-analyzer`. Some functions of the plugin may not work correctly, e.g. [this](https://github.com/sublimelsp/LSP-rust-analyzer/pull/64) recent case. Maybe I could add a check for the system binary version and display a popup/status message indicating that the version is unsupported?

Closes https://github.com/sublimelsp/LSP-rust-analyzer/issues/68