### PR TITLE
Upstream Inlay Hints

### DIFF
--- a/LSP-rust-analyzer.sublime-settings
+++ b/LSP-rust-analyzer.sublime-settings
@@ -166,16 +166,12 @@
 		"rust-analyzer.hoverActions.run": true,
 		//Whether to show inlay type hints for method chains.
 		"rust-analyzer.inlayHints.chainingHints": true,
-		//Whether to show inlay hints.
-		"rust-analyzer.inlayHints.enable": true,
 		// Whether to hide inlay hints for constructors.
 		"rust-analyzer.inlayHints.hideNamedConstructorHints": false,
 		//Maximum length for inlay hints. Set to null to have an unlimited length.
 		"rust-analyzer.inlayHints.maxLength": 25,
 		//Whether to show function parameter name inlay hints at the call site.
 		"rust-analyzer.inlayHints.parameterHints": true,
-		//Whether inlay hints font size should be smaller than editor's font size.
-		"rust-analyzer.inlayHints.smallerHints": true,
 		//Whether to show inlay type hints for variables.
 		"rust-analyzer.inlayHints.typeHints": true,
 		//Join lines merges consecutive declaration and initialization of an assignment.


### PR DESCRIPTION
Now that LSP supports inlay hints, and rust-analyzer has upstreamed them it makes sense to upstream inlay hints too so we can finally use the latest version of rust-analyzer instead of the backdated version which uses the legacy system (#73).

There are a few things that need to happen before this PR is merged, I haven't updated the config files to expose all the new features in rust-analyzer as I am not sure what they are and inlay hints appear to still be a bit early days as they're a bit busted at least on my machine ([see this comment](https://github.com/sublimelsp/LSP-rust-analyzer/issues/73#issuecomment-1229688198)).

I have gone ahead and removed all the relevant inlay hint code as it doesn't appear to be required with the new system. `rust-analyzer.inlayHints.smallerHints` appears to be broken as well. The other parameters relating to inlay hints seem to work though.

Inlay hints can be enabled in the latest github dev version of LSP by setting `"show_inlay_hints": true` in LSP's settings.

Thanks,
Aaron.