### PR TITLE
Update to server tag 2022-08-29 and remove legacy inline hints

### DIFF
--- a/LSP-rust-analyzer.sublime-settings
+++ b/LSP-rust-analyzer.sublime-settings
@@ -1,6 +1,4 @@
 {
-	"selector": "source.rust",
-	"command": ["${storage_path}/LSP-rust-analyzer/rust-analyzer"],
 	"settings": {
 
 		// Settings Not Related to rust-analyzer Server
@@ -12,229 +10,369 @@
 
 		// Rust-Analyzer Server Settings
 
-		//Whether to allow import insertion to merge new imports into single path glob imports like `use std::fmt::*;`.
-		"rust-analyzer.assist.allowMergingIntoGlobImports": true,
-		// Placeholder for missing expressions in assists. Possible values: todo, default
-		"rust-analyzer.assist.exprFillDefault": "todo",
-		//Whether to enforce the import granularity setting for all files. If set to false rust-analyzer will try to keep import styles consistent per file.
-		"rust-analyzer.assist.importEnforceGranularity": false,
-		//How imports should be grouped into use statements.
-		"rust-analyzer.assist.importGranularity": "crate",
-		//Group inserted imports by the [following order](https://rust-analyzer.github.io/manual.html#auto-import). Groups are separated by newlines.
-		"rust-analyzer.assist.importGroup": true,
-		//The path structure for newly inserted paths to use.
-		"rust-analyzer.assist.importPrefix": "plain",
+		// Placeholder expression to use for missing expressions in assists.
+		// possible values: todo, default
+		"rust-analyzer.assist.expressionFillDefault": "todo",
 		// Warm up caches on project load.
-		"rust-analyzer.cache.warmup": true,
-		//Show function name and docs in parameter hints.
-		"rust-analyzer.callInfo.full": true,
-		//Activate all available features (`--all-features`).
-		"rust-analyzer.cargo.allFeatures": false,
-		//Automatically refresh project info via `cargo metadata` on `Cargo.toml` changes.
+		"rust-analyzer.cachePriming.enable": true,
+		// How many worker threads to handle priming caches. The default `0` means to pick automatically.
+		"rust-analyzer.cachePriming.numThreads": 0,
+		// Automatically refresh project info via `cargo metadata` on
+		// `Cargo.toml` or `.cargo/config.toml` changes.
 		"rust-analyzer.cargo.autoreload": true,
-		//List of features to activate.
+		// Run build scripts (`build.rs`) for more precise code analysis.
+		"rust-analyzer.cargo.buildScripts.enable": true,
+		// Override the command rust-analyzer uses to run build scripts and
+		// build procedural macros. The command is required to output json
+		// and should therefore include `--message-format=json` or a similar
+		// option.
+		// By default, a cargo invocation will be constructed for the configured
+		// targets and features, with the following base command line:
+		// ```bash
+		// cargo check --quiet --workspace --message-format=json --all-targets
+		// ```
+		// .
+		"rust-analyzer.cargo.buildScripts.overrideCommand": null,
+		// Use `RUSTC_WRAPPER=rust-analyzer` when running build scripts to
+		// avoid checking unnecessary things.
+		"rust-analyzer.cargo.buildScripts.useRustcWrapper": true,
+		// List of features to activate.
+		// Set this to `"all"` to pass `--all-features` to cargo.
 		"rust-analyzer.cargo.features": [],
-		//Do not activate the `default` feature.
+		// Whether to pass `--no-default-features` to cargo.
 		"rust-analyzer.cargo.noDefaultFeatures": false,
-		//Internal config for debugging, disables loading of sysroot crates.
+		// Internal config for debugging, disables loading of sysroot crates.
 		"rust-analyzer.cargo.noSysroot": false,
-		//Run build scripts (`build.rs`) for more precise code analysis.
-		"rust-analyzer.cargo.runBuildScripts": true,
-		//Compilation target (target triple).
+		// Compilation target override (target triple).
 		"rust-analyzer.cargo.target": null,
-		//Unsets `#[cfg(test)]` for the specified crates.
-		"rust-analyzer.cargo.unsetTest": ["core"],
-		//Use `RUSTC_WRAPPER=rust-analyzer` when running build scripts to avoid compiling unnecessary things.
-		"rust-analyzer.cargo.useRustcWrapperForBuildScripts": true,
-		//Custom cargo runner extension ID.
+		// Unsets `#[cfg(test)]` for the specified crates.
+		"rust-analyzer.cargo.unsetTest": [
+		    "core"
+		],
+		// Custom cargo runner extension ID.
 		"rust-analyzer.cargoRunner": null,
-		//Check with all features (`--all-features`). Defaults to `#rust-analyzer.cargo.allFeatures#`.
-		"rust-analyzer.checkOnSave.allFeatures": null,
-		//Check all targets and tests (`--all-targets`).
+		// Check all targets and tests (`--all-targets`).
 		"rust-analyzer.checkOnSave.allTargets": true,
-		//Cargo command to use for `cargo check`.
+		// Cargo command to use for `cargo check`.
 		"rust-analyzer.checkOnSave.command": "check",
-		//Run specified `cargo check` command for diagnostics on save.
+		// Run specified `cargo check` command for diagnostics on save.
 		"rust-analyzer.checkOnSave.enable": true,
-		//Extra arguments for `cargo check`.
+		// Extra arguments for `cargo check`.
 		"rust-analyzer.checkOnSave.extraArgs": [],
-		//List of features to activate. Defaults to `#rust-analyzer.cargo.features#`.
+		// List of features to activate. Defaults to
+		// `#rust-analyzer.cargo.features#`.
+		// Set to `"all"` to pass `--all-features` to Cargo.
 		"rust-analyzer.checkOnSave.features": null,
-		//Do not activate the `default` feature.
+		// Whether to pass `--no-default-features` to Cargo. Defaults to
+		// `#rust-analyzer.cargo.noDefaultFeatures#`.
 		"rust-analyzer.checkOnSave.noDefaultFeatures": null,
-		//Advanced option, fully override the command rust-analyzer uses for checking. The command should include `--message-format=json` or similar option.
+		// Override the command rust-analyzer uses instead of `cargo check` for
+		// diagnostics on save. The command is required to output json and
+		// should therefor include `--message-format=json` or a similar option.
+		// If you're changing this because you're using some tool wrapping
+		// Cargo, you might also want to change
+		// `#rust-analyzer.cargo.buildScripts.overrideCommand#`.
+		// If there are multiple linked projects, this command is invoked for
+		// each of them, with the working directory being the project root
+		// (i.e., the folder containing the `Cargo.toml`).
+		// An example command would be:
+		// ```bash
+		// cargo check --workspace --message-format=json --all-targets
+		// ```
+		// .
 		"rust-analyzer.checkOnSave.overrideCommand": null,
-		//Check for a specific target. Defaults to `#rust-analyzer.cargo.target#`.
+		// Check for a specific target. Defaults to
+		// `#rust-analyzer.cargo.target#`.
 		"rust-analyzer.checkOnSave.target": null,
-		//Whether to add argument snippets when completing functions. Only applies when `#rust-analyzer.completion.addCallParenthesis#` is set.
-		"rust-analyzer.completion.addCallArgumentSnippets": true,
-		//Whether to add parenthesis when completing functions.
-		"rust-analyzer.completion.addCallParenthesis": true,
-		//Toggles the additional completions that automatically add imports when completed. Note that your client must specify the `additionalTextEdits` LSP client capability to truly have this feature enabled.
+		// Toggles the additional completions that automatically add imports when completed.
+		// Note that your client must specify the `additionalTextEdits` LSP client capability to truly have this feature enabled.
 		"rust-analyzer.completion.autoimport.enable": true,
-		//Toggles the additional completions that automatically show method calls and field accesses with `self` prefixed to them when inside a method.
+		// Toggles the additional completions that automatically show method calls and field accesses
+		// with `self` prefixed to them when inside a method.
 		"rust-analyzer.completion.autoself.enable": true,
-		//Whether to show postfix snippets like `dbg`, `if`, `not`, etc.
+		// Whether to add parenthesis and argument snippets when completing function.
+		// possible values: fill_arguments, add_parentheses, none
+		"rust-analyzer.completion.callable.snippets": "fill_arguments",
+		// Whether to show postfix snippets like `dbg`, `if`, `not`, etc.
 		"rust-analyzer.completion.postfix.enable": true,
+		// Enables completions of private items and fields that are defined in the current workspace even if they are not visible
+		// at the current position.
+		"rust-analyzer.completion.privateEditable.enable": false,
 		// Custom completion snippets.
-		"rust-analyzer.completion.snippets": {
-			"Ok": {
-				"scope": "expr",
-				"body": "Ok(${receiver})",
-				"postfix": "ok",
-				"description": "Wrap the expression in a `Result::Ok`"
-			},
-			"Box::pin": {
-				"requires": "std::boxed::Box",
-				"scope": "expr",
-				"body": "Box::pin(${receiver})",
-				"postfix": "pinbox",
-				"description": "Put the expression into a pinned `Box`"
-			},
-			"Err": {
-				"scope": "expr",
-				"body": "Err(${receiver})",
-				"postfix": "err",
-				"description": "Wrap the expression in a `Result::Err`"
-			},
-			"Rc::new": {
-				"requires": "std::rc::Rc",
-				"scope": "expr",
-				"body": "Rc::new(${receiver})",
-				"postfix": "rc",
-				"description": "Put the expression into an `Rc`"
-			},
-			"Some": {
-				"scope": "expr",
-				"body": "Some(${receiver})",
-				"postfix": "some",
-				"description": "Wrap the expression in an `Option::Some`"
-			},
-			"Arc::new": {
-				"requires": "std::sync::Arc",
-				"scope": "expr",
-				"body": "Arc::new(${receiver})",
-				"postfix": "arc",
-				"description": "Put the expression into an `Arc`"
-			}
+		"rust-analyzer.completion.snippets.custom": {
+		    "Box::pin": {
+		        "postfix": "pinbox",
+		        "requires": "std::boxed::Box",
+		        "body": "Box::pin(${receiver})",
+		        "description": "Put the expression into a pinned `Box`",
+		        "scope": "expr"
+		    },
+		    "Some": {
+		        "postfix": "some",
+		        "body": "Some(${receiver})",
+		        "description": "Wrap the expression in an `Option::Some`",
+		        "scope": "expr"
+		    },
+		    "Rc::new": {
+		        "postfix": "rc",
+		        "requires": "std::rc::Rc",
+		        "body": "Rc::new(${receiver})",
+		        "description": "Put the expression into an `Rc`",
+		        "scope": "expr"
+		    },
+		    "Ok": {
+		        "postfix": "ok",
+		        "body": "Ok(${receiver})",
+		        "description": "Wrap the expression in a `Result::Ok`",
+		        "scope": "expr"
+		    },
+		    "Err": {
+		        "postfix": "err",
+		        "body": "Err(${receiver})",
+		        "description": "Wrap the expression in a `Result::Err`",
+		        "scope": "expr"
+		    },
+		    "Arc::new": {
+		        "postfix": "arc",
+		        "requires": "std::sync::Arc",
+		        "body": "Arc::new(${receiver})",
+		        "description": "Put the expression into an `Arc`",
+		        "scope": "expr"
+		    }
 		},
-		//List of rust-analyzer diagnostics to disable.
+		// List of rust-analyzer diagnostics to disable.
 		"rust-analyzer.diagnostics.disabled": [],
-		//Whether to show native rust-analyzer diagnostics.
+		// Whether to show native rust-analyzer diagnostics.
 		"rust-analyzer.diagnostics.enable": true,
-		//Whether to show experimental rust-analyzer diagnostics that might have more false positives than usual.
-		"rust-analyzer.diagnostics.enableExperimental": true,
-		//Map of prefixes to be substituted when parsing diagnostic file paths. This should be the reverse mapping of what is passed to `rustc` as `--remap-path-prefix`.
+		// Whether to show experimental rust-analyzer diagnostics that might
+		// have more false positives than usual.
+		"rust-analyzer.diagnostics.experimental.enable": false,
+		// Map of prefixes to be substituted when parsing diagnostic file paths.
+		// This should be the reverse mapping of what is passed to `rustc` as `--remap-path-prefix`.
 		"rust-analyzer.diagnostics.remapPrefix": {},
-		//List of warnings that should be displayed with hint severity.  The warnings will be indicated by faded text or three dots in code and will not show up in the `Problems Panel`.
+		// List of warnings that should be displayed with hint severity.
+		// The warnings will be indicated by faded text or three dots in code
+		// and will not show up in the `Problems Panel`.
 		"rust-analyzer.diagnostics.warningsAsHint": [],
-		//List of warnings that should be displayed with info severity.  The warnings will be indicated by a blue squiggly underline in code and a blue icon in the `Problems Panel`.
+		// List of warnings that should be displayed with info severity.
+		// The warnings will be indicated by a blue squiggly underline in code
+		// and a blue icon in the `Problems Panel`.
 		"rust-analyzer.diagnostics.warningsAsInfo": [],
-		//Expand attribute macros.
-		"rust-analyzer.experimental.procAttrMacros": true,
-		//These directories will be ignored by rust-analyzer.
+		// These directories will be ignored by rust-analyzer. They are
+		// relative to the workspace root, and globs are not supported. You may
+		// also need to add the folders to Code's `files.watcherExclude`.
 		"rust-analyzer.files.excludeDirs": [],
-		//Controls file watching implementation.
+		// Controls file watching implementation.
+		// possible values: client, server
 		"rust-analyzer.files.watcher": "client",
-		// Enables highlighting of related references while hovering your mouse `break`, `loop`, `while`, or `for` keywords.
-		"rust-analyzer.highlightRelated.breakPoints": true,
-		// Enables highlighting of all exit points while hovering your mouse above any `return`, `?`, or return type arrow (`->`).
-		"rust-analyzer.highlightRelated.exitPoints": true,
-		// Enables highlighting of related references while hovering your mouse above any identifier.
-		"rust-analyzer.highlightRelated.references": true,
-		// Enables highlighting of all break points for a loop or block context while hovering your mouse above any `async` or `await` keywords.
-		"rust-analyzer.highlightRelated.yieldPoints": true,
-		// Use semantic tokens for strings. In some editors (e.g. vscode) semantic tokens override other highlighting grammars. By disabling semantic tokens for strings, other grammars can be used to highlight their contents. Use semantic tokens for strings.  In some editors (e.g. vscode) semantic tokens override other highlighting grammars. By disabling semantic tokens for strings, other grammars can be used to highlight their contents.
-		"rust-analyzer.highlighting.strings": true,
+		// Enables highlighting of related references while the cursor is on `break`, `loop`, `while`, or `for` keywords.
+		"rust-analyzer.highlightRelated.breakPoints.enable": true,
+		// Enables highlighting of all exit points while the cursor is on any `return`, `?`, `fn`, or return type arrow (`->`).
+		"rust-analyzer.highlightRelated.exitPoints.enable": true,
+		// Enables highlighting of related references while the cursor is on any identifier.
+		"rust-analyzer.highlightRelated.references.enable": true,
+		// Enables highlighting of all break points for a loop or block context while the cursor is on any `async` or `await`
+		// keywords.
+		"rust-analyzer.highlightRelated.yieldPoints.enable": true,
+		// Whether to show `Debug` action. Only applies when
+		// `#rust-analyzer.hover.actions.enable#` is set.
+		"rust-analyzer.hover.actions.debug.enable": true,
+		// Whether to show HoverActions in Rust files.
+		"rust-analyzer.hover.actions.enable": true,
+		// Whether to show `Go to Type Definition` action. Only applies when
+		// `#rust-analyzer.hover.actions.enable#` is set.
+		"rust-analyzer.hover.actions.gotoTypeDef.enable": true,
+		// Whether to show `Implementations` action. Only applies when
+		// `#rust-analyzer.hover.actions.enable#` is set.
+		"rust-analyzer.hover.actions.implementations.enable": true,
+		// Whether to show `References` action. Only applies when
+		// `#rust-analyzer.hover.actions.enable#` is set.
+		"rust-analyzer.hover.actions.references.enable": false,
+		// Whether to show `Run` action. Only applies when
+		// `#rust-analyzer.hover.actions.enable#` is set.
+		"rust-analyzer.hover.actions.run.enable": true,
 		// Whether to show documentation on hover.
-		"rust-analyzer.hover.documentation": true,
+		"rust-analyzer.hover.documentation.enable": true,
+		// Whether to show keyword hover popups. Only applies when
+		// `#rust-analyzer.hover.documentation.enable#` is set.
+		"rust-analyzer.hover.documentation.keywords.enable": true,
 		// Use markdown syntax for links in hover.
-		"rust-analyzer.hover.linksInHover": true,
-		//Whether to show `Debug` action. Only applies when `#rust-analyzer.hoverActions.enable#` is set.
-		"rust-analyzer.hoverActions.debug": true,
-		//Whether to show HoverActions in Rust files.
-		"rust-analyzer.hoverActions.enable": true,
-		//Whether to show `Go to Type Definition` action. Only applies when `#rust-analyzer.hoverActions.enable#` is set.
-		"rust-analyzer.hoverActions.gotoTypeDef": true,
-		//Whether to show `Implementations` action. Only applies when `#rust-analyzer.hoverActions.enable#` is set.
-		"rust-analyzer.hoverActions.implementations": true,
-		//Use markdown syntax for links in hover.
-		"rust-analyzer.hoverActions.linksInHover": true,
-		//Whether to show `References` action. Only applies when `#rust-analyzer.hoverActions.enable#` is set.
-		"rust-analyzer.hoverActions.references": false,
-		//Whether to show `Run` action. Only applies when `#rust-analyzer.hoverActions.enable#` is set.
-		"rust-analyzer.hoverActions.run": true,
-		//Whether to show inlay type hints for method chains.
-		"rust-analyzer.inlayHints.chainingHints": true,
-		//Whether to show inlay hints.
-		"rust-analyzer.inlayHints.enable": true,
-		// Whether to hide inlay hints for constructors.
-		"rust-analyzer.inlayHints.hideNamedConstructorHints": false,
-		//Maximum length for inlay hints. Set to null to have an unlimited length.
+		"rust-analyzer.hover.links.enable": true,
+		// Whether to enforce the import granularity setting for all files. If set to false rust-analyzer will try to keep import
+		// styles consistent per file.
+		"rust-analyzer.imports.granularity.enforce": false,
+		// How imports should be grouped into use statements.
+		// possible values: preserve, crate, module, item
+		"rust-analyzer.imports.granularity.group": "crate",
+		// Group inserted imports by the [following order](https://rust-analyzer.github.io/manual.html#auto-import). Groups are
+		// separated by newlines.
+		"rust-analyzer.imports.group.enable": true,
+		// Whether to allow import insertion to merge new imports into single path glob imports like `use std::fmt::*;`.
+		"rust-analyzer.imports.merge.glob": true,
+		// The path structure for newly inserted paths to use.
+		// possible values: plain, self, crate
+		"rust-analyzer.imports.prefix": "plain",
+		// Whether to show inlay type hints for binding modes.
+		"rust-analyzer.inlayHints.bindingModeHints.enable": false,
+		// Whether to show inlay type hints for method chains.
+		"rust-analyzer.inlayHints.chainingHints.enable": true,
+		// Whether to show inlay hints after a closing `}` to indicate what item it belongs to.
+		"rust-analyzer.inlayHints.closingBraceHints.enable": true,
+		// Minimum number of lines required before the `}` until the hint is shown (set to 0 or 1
+		// to always show them).
+		"rust-analyzer.inlayHints.closingBraceHints.minLines": 25,
+		// Whether to show inlay type hints for return types of closures.
+		// possible values: always, never, with_block
+		"rust-analyzer.inlayHints.closureReturnTypeHints.enable": "never",
+		// Whether to show inlay type hints for elided lifetimes in function signatures.
+		// possible values: always, never, skip_trivial
+		"rust-analyzer.inlayHints.lifetimeElisionHints.enable": "never",
+		// Whether to prefer using parameter names as the name for elided lifetime hints if possible.
+		"rust-analyzer.inlayHints.lifetimeElisionHints.useParameterNames": false,
+		// Maximum length for inlay hints. Set to null to have an unlimited length.
 		"rust-analyzer.inlayHints.maxLength": 25,
-		//Whether to show function parameter name inlay hints at the call site.
-		"rust-analyzer.inlayHints.parameterHints": true,
-		//Whether inlay hints font size should be smaller than editor's font size.
-		"rust-analyzer.inlayHints.smallerHints": true,
-		//Whether to show inlay type hints for variables.
-		"rust-analyzer.inlayHints.typeHints": true,
-		//Join lines merges consecutive declaration and initialization of an assignment.
+		// Whether to show function parameter name inlay hints at the call site.
+		"rust-analyzer.inlayHints.parameterHints.enable": true,
+		// Whether to show inlay type hints for compiler inserted reborrows.
+		// possible values: always, never, mutable
+		"rust-analyzer.inlayHints.reborrowHints.enable": "never",
+		// Whether to render leading colons for type hints, and trailing colons for parameter hints.
+		"rust-analyzer.inlayHints.renderColons": true,
+		// Whether to show inlay type hints for variables.
+		"rust-analyzer.inlayHints.typeHints.enable": true,
+		// Whether to hide inlay type hints for `let` statements that initialize to a closure.
+		// Only applies to closures with blocks, same as `#rust-analyzer.inlayHints.closureReturnTypeHints.enable#`.
+		"rust-analyzer.inlayHints.typeHints.hideClosureInitialization": false,
+		// Whether to hide inlay type hints for constructors.
+		"rust-analyzer.inlayHints.typeHints.hideNamedConstructor": false,
+		// Join lines merges consecutive declaration and initialization of an assignment.
 		"rust-analyzer.joinLines.joinAssignments": true,
-		//Join lines inserts else between consecutive ifs.
+		// Join lines inserts else between consecutive ifs.
 		"rust-analyzer.joinLines.joinElseIf": true,
-		//Join lines removes trailing commas.
+		// Join lines removes trailing commas.
 		"rust-analyzer.joinLines.removeTrailingComma": true,
-		//Join lines unwraps trivial blocks.
+		// Join lines unwraps trivial blocks.
 		"rust-analyzer.joinLines.unwrapTrivialBlock": true,
-		//Whether to show `Debug` lens. Only applies when `#rust-analyzer.lens.enable#` is set.
-		"rust-analyzer.lens.debug": true,
-		//Whether to show CodeLens in Rust files.
+		// Whether to show `Debug` lens. Only applies when
+		// `#rust-analyzer.lens.enable#` is set.
+		"rust-analyzer.lens.debug.enable": true,
+		// Whether to show CodeLens in Rust files.
 		"rust-analyzer.lens.enable": true,
-		// Whether to show `References` lens for Enum Variants. Only applies when `#rust-analyzer.lens.enable#` is set.
-		"rust-analyzer.lens.enumVariantReferences": false,
-		// Internal config: use custom client-side commands even when the client doesn't set the corresponding capability.
+		// Internal config: use custom client-side commands even when the
+		// client doesn't set the corresponding capability.
 		"rust-analyzer.lens.forceCustomCommands": true,
-		//Whether to show `Implementations` lens. Only applies when `#rust-analyzer.lens.enable#` is set.
-		"rust-analyzer.lens.implementations": true,
-		//Whether to show `Method References` lens. Only applies when `#rust-analyzer.lens.enable#` is set.
-		"rust-analyzer.lens.methodReferences": false,
-		//Whether to show `References` lens. Only applies when `#rust-analyzer.lens.enable#` is set.
-		"rust-analyzer.lens.references": false,
-		//Whether to show `Run` lens. Only applies when `#rust-analyzer.lens.enable#` is set.
-		"rust-analyzer.lens.run": true,
-		//Disable project auto-discovery in favor of explicitly specified set of projects.  Elements must be paths pointing to `Cargo.toml`, `rust-project.json`, or JSON objects in `rust-project.json` format.
+		// Whether to show `Implementations` lens. Only applies when
+		// `#rust-analyzer.lens.enable#` is set.
+		"rust-analyzer.lens.implementations.enable": true,
+		// Whether to show `References` lens for Struct, Enum, and Union.
+		// Only applies when `#rust-analyzer.lens.enable#` is set.
+		"rust-analyzer.lens.references.adt.enable": false,
+		// Whether to show `References` lens for Enum Variants.
+		// Only applies when `#rust-analyzer.lens.enable#` is set.
+		"rust-analyzer.lens.references.enumVariant.enable": false,
+		// Whether to show `Method References` lens. Only applies when
+		// `#rust-analyzer.lens.enable#` is set.
+		"rust-analyzer.lens.references.method.enable": false,
+		// Whether to show `References` lens for Trait.
+		// Only applies when `#rust-analyzer.lens.enable#` is set.
+		"rust-analyzer.lens.references.trait.enable": false,
+		// Whether to show `Run` lens. Only applies when
+		// `#rust-analyzer.lens.enable#` is set.
+		"rust-analyzer.lens.run.enable": true,
+		// Disable project auto-discovery in favor of explicitly specified set
+		// of projects.
+		// Elements must be paths pointing to `Cargo.toml`,
+		// `rust-project.json`, or JSON objects in `rust-project.json` format.
 		"rust-analyzer.linkedProjects": [],
-		//Number of syntax trees rust-analyzer keeps in memory. Defaults to 128.
-		"rust-analyzer.lruCapacity": null,
-		//Whether to show `can't find Cargo.toml` error message.
+		// Number of syntax trees rust-analyzer keeps in memory. Defaults to 128.
+		"rust-analyzer.lru.capacity": null,
+		// Whether to show `can't find Cargo.toml` error message.
 		"rust-analyzer.notifications.cargoTomlNotFound": true,
-		//Enable support for procedural macros, implies `#rust-analyzer.cargo.runBuildScripts#`.
+		// Expand attribute macros. Requires `#rust-analyzer.procMacro.enable#` to be set.
+		"rust-analyzer.procMacro.attributes.enable": true,
+		// Enable support for procedural macros, implies `#rust-analyzer.cargo.buildScripts.enable#`.
 		"rust-analyzer.procMacro.enable": true,
-		// These proc-macros will be ignored when trying to expand them. This config takes a map of crate names with the exported proc-macro names to ignore as values.
+		// These proc-macros will be ignored when trying to expand them.
+		// This config takes a map of crate names with the exported proc-macro names to ignore as values.
 		"rust-analyzer.procMacro.ignored": {},
-		//Internal config, path to proc-macro server executable (typically, this is rust-analyzer itself, but we override this in tests).
+		// Internal config, path to proc-macro server executable (typically,
+		// this is rust-analyzer itself, but we override this in tests).
 		"rust-analyzer.procMacro.server": null,
-		//Environment variables passed to the runnable launched using `Test` or `Debug` lens or `rust-analyzer.run` command.
+		// Whether to restart the server automatically when certain settings that require a restart are changed.
+		"rust-analyzer.restartServerOnConfigChange": false,
+		// Environment variables passed to the runnable launched using `Test` or `Debug` lens or `rust-analyzer.run` command.
 		"rust-analyzer.runnableEnv": null,
-		//Additional arguments to be passed to cargo for runnables such as tests or binaries. For example, it may be `--release`.
-		"rust-analyzer.runnables.cargoExtraArgs": [],
-		//Command to be executed instead of 'cargo' for runnables.
-		"rust-analyzer.runnables.overrideCargo": null,
-		//Path to the Cargo.toml of the rust compiler workspace, for usage in rustc_private projects, or "discover" to try to automatically find it.  Any project which uses rust-analyzer with the rustcPrivate crates must set `[package.metadata.rust-analyzer] rustc_private=true` to use it.  This option is not reloaded automatically; you must restart rust-analyzer for it to take effect.
-		"rust-analyzer.rustcSource": null,
-		//Enables the use of rustfmt's unstable range formatting command for the `textDocument/rangeFormatting` request. The rustfmt option is unstable and only available on a nightly build.
-		"rust-analyzer.rustfmt.enableRangeFormatting": false,
-		//Additional arguments to `rustfmt`.
+		// Command to be executed instead of 'cargo' for runnables.
+		"rust-analyzer.runnables.command": null,
+		// Additional arguments to be passed to cargo for runnables such as
+		// tests or binaries. For example, it may be `--release`.
+		"rust-analyzer.runnables.extraArgs": [],
+		// Path to the Cargo.toml of the rust compiler workspace, for usage in rustc_private
+		// projects, or "discover" to try to automatically find it if the `rustc-dev` component
+		// is installed.
+		// Any project which uses rust-analyzer with the rustcPrivate
+		// crates must set `[package.metadata.rust-analyzer] rustc_private=true` to use it.
+		// This option does not take effect until rust-analyzer is restarted.
+		"rust-analyzer.rustc.source": null,
+		// Additional arguments to `rustfmt`.
 		"rust-analyzer.rustfmt.extraArgs": [],
-		//Advanced option, fully override the command rust-analyzer uses for formatting.
+		// Advanced option, fully override the command rust-analyzer uses for
+		// formatting.
 		"rust-analyzer.rustfmt.overrideCommand": null,
-		//Workspace symbol search kind.
+		// Enables the use of rustfmt's unstable range formatting command for the
+		// `textDocument/rangeFormatting` request. The rustfmt option is unstable and only
+		// available on a nightly build.
+		"rust-analyzer.rustfmt.rangeFormatting.enable": false,
+		// Inject additional highlighting into doc comments.
+		// When enabled, rust-analyzer will highlight rust source in doc comments as well as intra
+		// doc links.
+		"rust-analyzer.semanticHighlighting.doc.comment.inject.enable": true,
+		// Use semantic tokens for operators.
+		// When disabled, rust-analyzer will emit semantic tokens only for operator tokens when
+		// they are tagged with modifiers.
+		"rust-analyzer.semanticHighlighting.operator.enable": true,
+		// Use specialized semantic tokens for operators.
+		// When enabled, rust-analyzer will emit special token types for operator tokens instead
+		// of the generic `operator` token type.
+		"rust-analyzer.semanticHighlighting.operator.specialization.enable": false,
+		// Use semantic tokens for punctuations.
+		// When disabled, rust-analyzer will emit semantic tokens only for punctuation tokens when
+		// they are tagged with modifiers or have a special role.
+		"rust-analyzer.semanticHighlighting.punctuation.enable": false,
+		// When enabled, rust-analyzer will emit a punctuation semantic token for the `!` of macro
+		// calls.
+		"rust-analyzer.semanticHighlighting.punctuation.separate.macro.bang": false,
+		// Use specialized semantic tokens for punctuations.
+		// When enabled, rust-analyzer will emit special token types for punctuation tokens instead
+		// of the generic `punctuation` token type.
+		"rust-analyzer.semanticHighlighting.punctuation.specialization.enable": false,
+		// Use semantic tokens for strings.
+		// In some editors (e.g. vscode) semantic tokens override other highlighting grammars.
+		// By disabling semantic tokens for strings, other grammars can be used to highlight
+		// their contents.
+		"rust-analyzer.semanticHighlighting.strings.enable": true,
+		// Show full signature of the callable. Only shows parameters if disabled.
+		// possible values: full, parameters
+		"rust-analyzer.signatureInfo.detail": "full",
+		// Show documentation.
+		"rust-analyzer.signatureInfo.documentation.enable": true,
+		// Whether to insert closing angle brackets when typing an opening angle bracket of a generic argument list.
+		"rust-analyzer.typing.autoClosingAngleBrackets.enable": false,
+		// Whether to prefix newlines after comments with the corresponding comment prefix.
+		"rust-analyzer.typing.continueCommentsOnNewline": true,
+		// Workspace symbol search kind.
+		// possible values: only_types, all_symbols
 		"rust-analyzer.workspace.symbol.search.kind": "only_types",
-		//Workspace symbol search scope.
-		"rust-analyzer.workspace.symbol.search.scope": "workspace"
+		// Limits the number of items returned from a workspace symbol search (Defaults to 128).
+		// Some clients like vs-code issue new searches on result filtering and don't require all results to be returned in the
+		// initial search.
+		// Other clients requires all results upfront and might require a higher limit.
+		"rust-analyzer.workspace.symbol.search.limit": 128,
+		// Workspace symbol search scope.
+		// possible values: workspace, workspace_and_dependencies
+		"rust-analyzer.workspace.symbol.search.scope": "workspace",
 	},
-	"experimental_capabilities": {
-		// empty for now
-	}
+	"selector": "source.rust",
+	"command": ["${storage_path}/LSP-rust-analyzer/rust-analyzer"],
 }
 

--- a/sublime-package.json
+++ b/sublime-package.json
@@ -31,12 +31,7 @@
                       "description": "Wether or not to spawn a panel at the bottom, or a new tab.",
                       "type": "boolean"
                     },
-                    "rust-analyzer.assist.allowMergingIntoGlobImports": {
-                      "default": true,
-                      "markdownDescription": "Whether to allow import insertion to merge new imports into single path glob imports like `use std::fmt::*;`.",
-                      "type": "boolean"
-                    },
-                    "rust-analyzer.assist.exprFillDefault": {
+                    "rust-analyzer.assist.expressionFillDefault": {
                       "default": "todo",
                       "enum": [
                         "todo",
@@ -46,82 +41,71 @@
                         "Fill missing expressions with the `todo` macro",
                         "Fill missing expressions with reasonable defaults, `new` or `default` constructors."
                       ],
-                      "markdownDescription": "Placeholder for missing expressions in assists.",
+                      "markdownDescription": "Placeholder expression to use for missing expressions in assists.",
                       "type": "string"
                     },
-                    "rust-analyzer.assist.importEnforceGranularity": {
-                      "default": false,
-                      "markdownDescription": "Whether to enforce the import granularity setting for all files. If set to false rust-analyzer will try to keep import styles consistent per file.",
-                      "type": "boolean"
-                    },
-                    "rust-analyzer.assist.importGranularity": {
-                      "default": "crate",
-                      "enum": [
-                        "preserve",
-                        "crate",
-                        "module",
-                        "item"
-                      ],
-                      "enumDescriptions": [
-                        "Do not change the granularity of any imports and preserve the original structure written by the developer.",
-                        "Merge imports from the same crate into a single use statement. Conversely, imports from different crates are split into separate statements.",
-                        "Merge imports from the same module into a single use statement. Conversely, imports from different modules are split into separate statements.",
-                        "Flatten imports so that each has its own use statement."
-                      ],
-                      "markdownDescription": "How imports should be grouped into use statements.",
-                      "type": "string"
-                    },
-                    "rust-analyzer.assist.importGroup": {
-                      "default": true,
-                      "markdownDescription": "Group inserted imports by the [following order](https://rust-analyzer.github.io/manual.html#auto-import). Groups are separated by newlines.",
-                      "type": "boolean"
-                    },
-                    "rust-analyzer.assist.importPrefix": {
-                      "default": "plain",
-                      "enum": [
-                        "plain",
-                        "self",
-                        "crate"
-                      ],
-                      "enumDescriptions": [
-                        "Insert import paths relative to the current module, using up to one `super` prefix if the parent module contains the requested item.",
-                        "Insert import paths relative to the current module, using up to one `super` prefix if the parent module contains the requested item. Prefixes `self` in front of the path if it starts with a module.",
-                        "Force import paths to be absolute by always starting them with `crate` or the extern crate name they come from."
-                      ],
-                      "markdownDescription": "The path structure for newly inserted paths to use.",
-                      "type": "string"
-                    },
-                    "rust-analyzer.cache.warmup": {
+                    "rust-analyzer.cachePriming.enable": {
                       "default": true,
                       "markdownDescription": "Warm up caches on project load.",
                       "type": "boolean"
                     },
-                    "rust-analyzer.callInfo.full": {
-                      "default": true,
-                      "markdownDescription": "Show function name and docs in parameter hints.",
-                      "type": "boolean"
-                    },
-                    "rust-analyzer.cargo.allFeatures": {
-                      "default": false,
-                      "markdownDescription": "Activate all available features (`--all-features`).",
-                      "type": "boolean"
+                    "rust-analyzer.cachePriming.numThreads": {
+                      "default": 0,
+                      "markdownDescription": "How many worker threads to handle priming caches. The default `0` means to pick automatically.",
+                      "maximum": 255,
+                      "minimum": 0,
+                      "type": "number"
                     },
                     "rust-analyzer.cargo.autoreload": {
                       "default": true,
-                      "markdownDescription": "Automatically refresh project info via `cargo metadata` on\n`Cargo.toml` changes.",
+                      "markdownDescription": "Automatically refresh project info via `cargo metadata` on\n`Cargo.toml` or `.cargo/config.toml` changes.",
                       "type": "boolean"
                     },
-                    "rust-analyzer.cargo.features": {
-                      "default": [],
+                    "rust-analyzer.cargo.buildScripts.enable": {
+                      "default": true,
+                      "markdownDescription": "Run build scripts (`build.rs`) for more precise code analysis.",
+                      "type": "boolean"
+                    },
+                    "rust-analyzer.cargo.buildScripts.overrideCommand": {
+                      "default": null,
                       "items": {
                         "type": "string"
                       },
-                      "markdownDescription": "List of features to activate.",
-                      "type": "array"
+                      "markdownDescription": "Override the command rust-analyzer uses to run build scripts and\nbuild procedural macros. The command is required to output json\nand should therefore include `--message-format=json` or a similar\noption.\n\nBy default, a cargo invocation will be constructed for the configured\ntargets and features, with the following base command line:\n\n```bash\ncargo check --quiet --workspace --message-format=json --all-targets\n```\n.",
+                      "type": [
+                        "null",
+                        "array"
+                      ]
+                    },
+                    "rust-analyzer.cargo.buildScripts.useRustcWrapper": {
+                      "default": true,
+                      "markdownDescription": "Use `RUSTC_WRAPPER=rust-analyzer` when running build scripts to\navoid checking unnecessary things.",
+                      "type": "boolean"
+                    },
+                    "rust-analyzer.cargo.features": {
+                      "anyOf": [
+                        {
+                          "enum": [
+                            "all"
+                          ],
+                          "enumDescriptions": [
+                            "Pass `--all-features` to cargo"
+                          ],
+                          "type": "string"
+                        },
+                        {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        }
+                      ],
+                      "default": [],
+                      "markdownDescription": "List of features to activate.\n\nSet this to `\"all\"` to pass `--all-features` to cargo."
                     },
                     "rust-analyzer.cargo.noDefaultFeatures": {
                       "default": false,
-                      "markdownDescription": "Do not activate the `default` feature.",
+                      "markdownDescription": "Whether to pass `--no-default-features` to cargo.",
                       "type": "boolean"
                     },
                     "rust-analyzer.cargo.noSysroot": {
@@ -129,14 +113,9 @@
                       "markdownDescription": "Internal config for debugging, disables loading of sysroot crates.",
                       "type": "boolean"
                     },
-                    "rust-analyzer.cargo.runBuildScripts": {
-                      "default": true,
-                      "markdownDescription": "Run build scripts (`build.rs`) for more precise code analysis.",
-                      "type": "boolean"
-                    },
                     "rust-analyzer.cargo.target": {
                       "default": null,
-                      "markdownDescription": "Compilation target (target triple).",
+                      "markdownDescription": "Compilation target override (target triple).",
                       "type": [
                         "null",
                         "string"
@@ -152,25 +131,12 @@
                       "markdownDescription": "Unsets `#[cfg(test)]` for the specified crates.",
                       "type": "array"
                     },
-                    "rust-analyzer.cargo.useRustcWrapperForBuildScripts": {
-                      "default": true,
-                      "markdownDescription": "Use `RUSTC_WRAPPER=rust-analyzer` when running build scripts to\navoid compiling unnecessary things.",
-                      "type": "boolean"
-                    },
                     "rust-analyzer.cargoRunner": {
                       "default": null,
                       "description": "Custom cargo runner extension ID.",
                       "type": [
                         "null",
                         "string"
-                      ]
-                    },
-                    "rust-analyzer.checkOnSave.allFeatures": {
-                      "default": null,
-                      "markdownDescription": "Check with all features (`--all-features`).\nDefaults to `#rust-analyzer.cargo.allFeatures#`.",
-                      "type": [
-                        "null",
-                        "boolean"
                       ]
                     },
                     "rust-analyzer.checkOnSave.allTargets": {
@@ -197,19 +163,32 @@
                       "type": "array"
                     },
                     "rust-analyzer.checkOnSave.features": {
+                      "anyOf": [
+                        {
+                          "enum": [
+                            "all"
+                          ],
+                          "enumDescriptions": [
+                            "Pass `--all-features` to cargo"
+                          ],
+                          "type": "string"
+                        },
+                        {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
                       "default": null,
-                      "items": {
-                        "type": "string"
-                      },
-                      "markdownDescription": "List of features to activate. Defaults to\n`#rust-analyzer.cargo.features#`.",
-                      "type": [
-                        "null",
-                        "array"
-                      ]
+                      "markdownDescription": "List of features to activate. Defaults to\n`#rust-analyzer.cargo.features#`.\n\nSet to `\"all\"` to pass `--all-features` to Cargo."
                     },
                     "rust-analyzer.checkOnSave.noDefaultFeatures": {
                       "default": null,
-                      "markdownDescription": "Do not activate the `default` feature.",
+                      "markdownDescription": "Whether to pass `--no-default-features` to Cargo. Defaults to\n`#rust-analyzer.cargo.noDefaultFeatures#`.",
                       "type": [
                         "null",
                         "boolean"
@@ -220,7 +199,7 @@
                       "items": {
                         "type": "string"
                       },
-                      "markdownDescription": "Advanced option, fully override the command rust-analyzer uses for\nchecking. The command should include `--message-format=json` or\nsimilar option.",
+                      "markdownDescription": "Override the command rust-analyzer uses instead of `cargo check` for\ndiagnostics on save. The command is required to output json and\nshould therefor include `--message-format=json` or a similar option.\n\nIf you're changing this because you're using some tool wrapping\nCargo, you might also want to change\n`#rust-analyzer.cargo.buildScripts.overrideCommand#`.\n\nIf there are multiple linked projects, this command is invoked for\neach of them, with the working directory being the project root\n(i.e., the folder containing the `Cargo.toml`).\n\nAn example command would be:\n\n```bash\ncargo check --workspace --message-format=json --all-targets\n```\n.",
                       "type": [
                         "null",
                         "array"
@@ -234,16 +213,6 @@
                         "string"
                       ]
                     },
-                    "rust-analyzer.completion.addCallArgumentSnippets": {
-                      "default": true,
-                      "markdownDescription": "Whether to add argument snippets when completing functions.\nOnly applies when `#rust-analyzer.completion.addCallParenthesis#` is set.",
-                      "type": "boolean"
-                    },
-                    "rust-analyzer.completion.addCallParenthesis": {
-                      "default": true,
-                      "markdownDescription": "Whether to add parenthesis when completing functions.",
-                      "type": "boolean"
-                    },
                     "rust-analyzer.completion.autoimport.enable": {
                       "default": true,
                       "markdownDescription": "Toggles the additional completions that automatically add imports when completed.\nNote that your client must specify the `additionalTextEdits` LSP client capability to truly have this feature enabled.",
@@ -254,12 +223,32 @@
                       "markdownDescription": "Toggles the additional completions that automatically show method calls and field accesses\nwith `self` prefixed to them when inside a method.",
                       "type": "boolean"
                     },
+                    "rust-analyzer.completion.callable.snippets": {
+                      "default": "fill_arguments",
+                      "enum": [
+                        "fill_arguments",
+                        "add_parentheses",
+                        "none"
+                      ],
+                      "enumDescriptions": [
+                        "Add call parentheses and pre-fill arguments.",
+                        "Add call parentheses.",
+                        "Do no snippet completions for callables."
+                      ],
+                      "markdownDescription": "Whether to add parenthesis and argument snippets when completing function.",
+                      "type": "string"
+                    },
                     "rust-analyzer.completion.postfix.enable": {
                       "default": true,
                       "markdownDescription": "Whether to show postfix snippets like `dbg`, `if`, `not`, etc.",
                       "type": "boolean"
                     },
-                    "rust-analyzer.completion.snippets": {
+                    "rust-analyzer.completion.privateEditable.enable": {
+                      "default": false,
+                      "markdownDescription": "Enables completions of private items and fields that are defined in the current workspace even if they are not visible at the current position.",
+                      "type": "boolean"
+                    },
+                    "rust-analyzer.completion.snippets.custom": {
                       "default": {
                         "Arc::new": {
                           "body": "Arc::new(${receiver})",
@@ -304,6 +293,42 @@
                       "markdownDescription": "Custom completion snippets.",
                       "type": "object"
                     },
+                    // "rust-analyzer.debug.engine": {
+                    //   "default": "auto",
+                    //   "description": "Preferred debug engine.",
+                    //   "enum": [
+                    //     "auto",
+                    //     "vadimcn.vscode-lldb",
+                    //     "ms-vscode.cpptools"
+                    //   ],
+                    //   "markdownEnumDescriptions": [
+                    //     "First try to use [CodeLLDB](https://marketplace.visualstudio.com/items?itemName=vadimcn.vscode-lldb), if it's not installed try to use [MS C++ tools](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools).",
+                    //     "Use [CodeLLDB](https://marketplace.visualstudio.com/items?itemName=vadimcn.vscode-lldb)",
+                    //     "Use [MS C++ tools](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)"
+                    //   ],
+                    //   "type": "string"
+                    // },
+                    // "rust-analyzer.debug.engineSettings": {
+                    //   "default": {},
+                    //   "markdownDescription": "Optional settings passed to the debug engine. Example: `{ \"lldb\": { \"terminal\":\"external\"} }`",
+                    //   "type": "object"
+                    // },
+                    // "rust-analyzer.debug.openDebugPane": {
+                    //   "default": false,
+                    //   "markdownDescription": "Whether to open up the `Debug Panel` on debugging start.",
+                    //   "type": "boolean"
+                    // },
+                    // "rust-analyzer.debug.sourceFileMap": {
+                    //   "const": "auto",
+                    //   "default": {
+                    //     "/rustc/<id>": "${env:USERPROFILE}/.rustup/toolchains/<toolchain-id>/lib/rustlib/src/rust"
+                    //   },
+                    //   "description": "Optional source file mappings passed to the debug engine.",
+                    //   "type": [
+                    //     "object",
+                    //     "string"
+                    //   ]
+                    // },
                     "rust-analyzer.diagnostics.disabled": {
                       "default": [],
                       "items": {
@@ -318,8 +343,8 @@
                       "markdownDescription": "Whether to show native rust-analyzer diagnostics.",
                       "type": "boolean"
                     },
-                    "rust-analyzer.diagnostics.enableExperimental": {
-                      "default": true,
+                    "rust-analyzer.diagnostics.experimental.enable": {
+                      "default": false,
                       "markdownDescription": "Whether to show experimental rust-analyzer diagnostics that might\nhave more false positives than usual.",
                       "type": "boolean"
                     },
@@ -344,11 +369,6 @@
                       "markdownDescription": "List of warnings that should be displayed with info severity.\n\nThe warnings will be indicated by a blue squiggly underline in code\nand a blue icon in the `Problems Panel`.",
                       "type": "array"
                     },
-                    "rust-analyzer.experimental.procAttrMacros": {
-                      "default": true,
-                      "markdownDescription": "Expand attribute macros.",
-                      "type": "boolean"
-                    },
                     "rust-analyzer.files.excludeDirs": {
                       "default": [],
                       "items": {
@@ -359,92 +379,183 @@
                     },
                     "rust-analyzer.files.watcher": {
                       "default": "client",
+                      "enum": [
+                        "client",
+                        "server"
+                      ],
+                      "enumDescriptions": [
+                        "Use the client (editor) to watch files for changes",
+                        "Use server-side file watching"
+                      ],
                       "markdownDescription": "Controls file watching implementation.",
                       "type": "string"
                     },
-                    "rust-analyzer.highlightRelated.breakPoints": {
+                    "rust-analyzer.highlightRelated.breakPoints.enable": {
                       "default": true,
-                      "markdownDescription": "Enables highlighting of related references while hovering your mouse `break`, `loop`, `while`, or `for` keywords.",
+                      "markdownDescription": "Enables highlighting of related references while the cursor is on `break`, `loop`, `while`, or `for` keywords.",
                       "type": "boolean"
                     },
-                    "rust-analyzer.highlightRelated.exitPoints": {
+                    "rust-analyzer.highlightRelated.exitPoints.enable": {
                       "default": true,
-                      "markdownDescription": "Enables highlighting of all exit points while hovering your mouse above any `return`, `?`, or return type arrow (`->`).",
+                      "markdownDescription": "Enables highlighting of all exit points while the cursor is on any `return`, `?`, `fn`, or return type arrow (`->`).",
                       "type": "boolean"
                     },
-                    "rust-analyzer.highlightRelated.references": {
+                    "rust-analyzer.highlightRelated.references.enable": {
                       "default": true,
-                      "markdownDescription": "Enables highlighting of related references while hovering your mouse above any identifier.",
+                      "markdownDescription": "Enables highlighting of related references while the cursor is on any identifier.",
                       "type": "boolean"
                     },
-                    "rust-analyzer.highlightRelated.yieldPoints": {
+                    "rust-analyzer.highlightRelated.yieldPoints.enable": {
                       "default": true,
-                      "markdownDescription": "Enables highlighting of all break points for a loop or block context while hovering your mouse above any `async` or `await` keywords.",
+                      "markdownDescription": "Enables highlighting of all break points for a loop or block context while the cursor is on any `async` or `await` keywords.",
                       "type": "boolean"
                     },
-                    "rust-analyzer.highlighting.strings": {
+                    "rust-analyzer.hover.actions.debug.enable": {
                       "default": true,
-                      "markdownDescription": "Use semantic tokens for strings.\n\nIn some editors (e.g. vscode) semantic tokens override other highlighting grammars.\nBy disabling semantic tokens for strings, other grammars can be used to highlight\ntheir contents.",
+                      "markdownDescription": "Whether to show `Debug` action. Only applies when\n`#rust-analyzer.hover.actions.enable#` is set.",
                       "type": "boolean"
                     },
-                    "rust-analyzer.hover.documentation": {
-                      "default": true,
-                      "markdownDescription": "Whether to show documentation on hover.",
-                      "type": "boolean"
-                    },
-                    "rust-analyzer.hover.linksInHover": {
-                      "default": true,
-                      "markdownDescription": "Use markdown syntax for links in hover.",
-                      "type": "boolean"
-                    },
-                    "rust-analyzer.hoverActions.debug": {
-                      "default": true,
-                      "markdownDescription": "Whether to show `Debug` action. Only applies when\n`#rust-analyzer.hoverActions.enable#` is set.",
-                      "type": "boolean"
-                    },
-                    "rust-analyzer.hoverActions.enable": {
+                    "rust-analyzer.hover.actions.enable": {
                       "default": true,
                       "markdownDescription": "Whether to show HoverActions in Rust files.",
                       "type": "boolean"
                     },
-                    "rust-analyzer.hoverActions.gotoTypeDef": {
+                    "rust-analyzer.hover.actions.gotoTypeDef.enable": {
                       "default": true,
-                      "markdownDescription": "Whether to show `Go to Type Definition` action. Only applies when\n`#rust-analyzer.hoverActions.enable#` is set.",
+                      "markdownDescription": "Whether to show `Go to Type Definition` action. Only applies when\n`#rust-analyzer.hover.actions.enable#` is set.",
                       "type": "boolean"
                     },
-                    "rust-analyzer.hoverActions.implementations": {
+                    "rust-analyzer.hover.actions.implementations.enable": {
                       "default": true,
-                      "markdownDescription": "Whether to show `Implementations` action. Only applies when\n`#rust-analyzer.hoverActions.enable#` is set.",
+                      "markdownDescription": "Whether to show `Implementations` action. Only applies when\n`#rust-analyzer.hover.actions.enable#` is set.",
                       "type": "boolean"
                     },
-                    "rust-analyzer.hoverActions.linksInHover": {
+                    "rust-analyzer.hover.actions.references.enable": {
+                      "default": false,
+                      "markdownDescription": "Whether to show `References` action. Only applies when\n`#rust-analyzer.hover.actions.enable#` is set.",
+                      "type": "boolean"
+                    },
+                    "rust-analyzer.hover.actions.run.enable": {
+                      "default": true,
+                      "markdownDescription": "Whether to show `Run` action. Only applies when\n`#rust-analyzer.hover.actions.enable#` is set.",
+                      "type": "boolean"
+                    },
+                    "rust-analyzer.hover.documentation.enable": {
+                      "default": true,
+                      "markdownDescription": "Whether to show documentation on hover.",
+                      "type": "boolean"
+                    },
+                    "rust-analyzer.hover.documentation.keywords.enable": {
+                      "default": true,
+                      "markdownDescription": "Whether to show keyword hover popups. Only applies when\n`#rust-analyzer.hover.documentation.enable#` is set.",
+                      "type": "boolean"
+                    },
+                    "rust-analyzer.hover.links.enable": {
                       "default": true,
                       "markdownDescription": "Use markdown syntax for links in hover.",
                       "type": "boolean"
                     },
-                    "rust-analyzer.hoverActions.references": {
+                    "rust-analyzer.imports.granularity.enforce": {
                       "default": false,
-                      "markdownDescription": "Whether to show `References` action. Only applies when\n`#rust-analyzer.hoverActions.enable#` is set.",
+                      "markdownDescription": "Whether to enforce the import granularity setting for all files. If set to false rust-analyzer will try to keep import styles consistent per file.",
                       "type": "boolean"
                     },
-                    "rust-analyzer.hoverActions.run": {
+                    "rust-analyzer.imports.granularity.group": {
+                      "default": "crate",
+                      "enum": [
+                        "preserve",
+                        "crate",
+                        "module",
+                        "item"
+                      ],
+                      "enumDescriptions": [
+                        "Do not change the granularity of any imports and preserve the original structure written by the developer.",
+                        "Merge imports from the same crate into a single use statement. Conversely, imports from different crates are split into separate statements.",
+                        "Merge imports from the same module into a single use statement. Conversely, imports from different modules are split into separate statements.",
+                        "Flatten imports so that each has its own use statement."
+                      ],
+                      "markdownDescription": "How imports should be grouped into use statements.",
+                      "type": "string"
+                    },
+                    "rust-analyzer.imports.group.enable": {
                       "default": true,
-                      "markdownDescription": "Whether to show `Run` action. Only applies when\n`#rust-analyzer.hoverActions.enable#` is set.",
+                      "markdownDescription": "Group inserted imports by the [following order](https://rust-analyzer.github.io/manual.html#auto-import). Groups are separated by newlines.",
                       "type": "boolean"
                     },
-                    "rust-analyzer.inlayHints.chainingHints": {
+                    "rust-analyzer.imports.merge.glob": {
+                      "default": true,
+                      "markdownDescription": "Whether to allow import insertion to merge new imports into single path glob imports like `use std::fmt::*;`.",
+                      "type": "boolean"
+                    },
+                    "rust-analyzer.imports.prefix": {
+                      "default": "plain",
+                      "enum": [
+                        "plain",
+                        "self",
+                        "crate"
+                      ],
+                      "enumDescriptions": [
+                        "Insert import paths relative to the current module, using up to one `super` prefix if the parent module contains the requested item.",
+                        "Insert import paths relative to the current module, using up to one `super` prefix if the parent module contains the requested item. Prefixes `self` in front of the path if it starts with a module.",
+                        "Force import paths to be absolute by always starting them with `crate` or the extern crate name they come from."
+                      ],
+                      "markdownDescription": "The path structure for newly inserted paths to use.",
+                      "type": "string"
+                    },
+                    "rust-analyzer.inlayHints.bindingModeHints.enable": {
+                      "default": false,
+                      "markdownDescription": "Whether to show inlay type hints for binding modes.",
+                      "type": "boolean"
+                    },
+                    "rust-analyzer.inlayHints.chainingHints.enable": {
                       "default": true,
                       "markdownDescription": "Whether to show inlay type hints for method chains.",
                       "type": "boolean"
                     },
-                    "rust-analyzer.inlayHints.enable": {
+                    "rust-analyzer.inlayHints.closingBraceHints.enable": {
                       "default": true,
-                      "description": "Whether to show inlay hints.",
+                      "markdownDescription": "Whether to show inlay hints after a closing `}` to indicate what item it belongs to.",
                       "type": "boolean"
                     },
-                    "rust-analyzer.inlayHints.hideNamedConstructorHints": {
+                    "rust-analyzer.inlayHints.closingBraceHints.minLines": {
+                      "default": 25,
+                      "markdownDescription": "Minimum number of lines required before the `}` until the hint is shown (set to 0 or 1\nto always show them).",
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "rust-analyzer.inlayHints.closureReturnTypeHints.enable": {
+                      "default": "never",
+                      "enum": [
+                        "always",
+                        "never",
+                        "with_block"
+                      ],
+                      "enumDescriptions": [
+                        "Always show type hints for return types of closures.",
+                        "Never show type hints for return types of closures.",
+                        "Only show type hints for return types of closures with blocks."
+                      ],
+                      "markdownDescription": "Whether to show inlay type hints for return types of closures.",
+                      "type": "string"
+                    },
+                    "rust-analyzer.inlayHints.lifetimeElisionHints.enable": {
+                      "default": "never",
+                      "enum": [
+                        "always",
+                        "never",
+                        "skip_trivial"
+                      ],
+                      "enumDescriptions": [
+                        "Always show lifetime elision hints.",
+                        "Never show lifetime elision hints.",
+                        "Only show lifetime elision hints if a return type is involved."
+                      ],
+                      "markdownDescription": "Whether to show inlay type hints for elided lifetimes in function signatures.",
+                      "type": "string"
+                    },
+                    "rust-analyzer.inlayHints.lifetimeElisionHints.useParameterNames": {
                       "default": false,
-                      "markdownDescription": "Whether to hide inlay hints for constructors.",
+                      "markdownDescription": "Whether to prefer using parameter names as the name for elided lifetime hints if possible.",
                       "type": "boolean"
                     },
                     "rust-analyzer.inlayHints.maxLength": {
@@ -456,19 +567,44 @@
                         "integer"
                       ]
                     },
-                    "rust-analyzer.inlayHints.parameterHints": {
+                    "rust-analyzer.inlayHints.parameterHints.enable": {
                       "default": true,
                       "markdownDescription": "Whether to show function parameter name inlay hints at the call\nsite.",
                       "type": "boolean"
                     },
-                    "rust-analyzer.inlayHints.smallerHints": {
+                    "rust-analyzer.inlayHints.reborrowHints.enable": {
+                      "default": "never",
+                      "enum": [
+                        "always",
+                        "never",
+                        "mutable"
+                      ],
+                      "enumDescriptions": [
+                        "Always show reborrow hints.",
+                        "Never show reborrow hints.",
+                        "Only show mutable reborrow hints."
+                      ],
+                      "markdownDescription": "Whether to show inlay type hints for compiler inserted reborrows.",
+                      "type": "string"
+                    },
+                    "rust-analyzer.inlayHints.renderColons": {
                       "default": true,
-                      "description": "Whether inlay hints font size should be smaller than editor's font size.",
+                      "markdownDescription": "Whether to render leading colons for type hints, and trailing colons for parameter hints.",
                       "type": "boolean"
                     },
-                    "rust-analyzer.inlayHints.typeHints": {
+                    "rust-analyzer.inlayHints.typeHints.enable": {
                       "default": true,
                       "markdownDescription": "Whether to show inlay type hints for variables.",
+                      "type": "boolean"
+                    },
+                    "rust-analyzer.inlayHints.typeHints.hideClosureInitialization": {
+                      "default": false,
+                      "markdownDescription": "Whether to hide inlay type hints for `let` statements that initialize to a closure.\nOnly applies to closures with blocks, same as `#rust-analyzer.inlayHints.closureReturnTypeHints.enable#`.",
+                      "type": "boolean"
+                    },
+                    "rust-analyzer.inlayHints.typeHints.hideNamedConstructor": {
+                      "default": false,
+                      "markdownDescription": "Whether to hide inlay type hints for constructors.",
                       "type": "boolean"
                     },
                     "rust-analyzer.joinLines.joinAssignments": {
@@ -491,7 +627,7 @@
                       "markdownDescription": "Join lines unwraps trivial blocks.",
                       "type": "boolean"
                     },
-                    "rust-analyzer.lens.debug": {
+                    "rust-analyzer.lens.debug.enable": {
                       "default": true,
                       "markdownDescription": "Whether to show `Debug` lens. Only applies when\n`#rust-analyzer.lens.enable#` is set.",
                       "type": "boolean"
@@ -501,32 +637,37 @@
                       "markdownDescription": "Whether to show CodeLens in Rust files.",
                       "type": "boolean"
                     },
-                    "rust-analyzer.lens.enumVariantReferences": {
-                      "default": false,
-                      "markdownDescription": "Whether to show `References` lens for Enum Variants.\nOnly applies when `#rust-analyzer.lens.enable#` is set.",
-                      "type": "boolean"
-                    },
                     "rust-analyzer.lens.forceCustomCommands": {
                       "default": true,
                       "markdownDescription": "Internal config: use custom client-side commands even when the\nclient doesn't set the corresponding capability.",
                       "type": "boolean"
                     },
-                    "rust-analyzer.lens.implementations": {
+                    "rust-analyzer.lens.implementations.enable": {
                       "default": true,
                       "markdownDescription": "Whether to show `Implementations` lens. Only applies when\n`#rust-analyzer.lens.enable#` is set.",
                       "type": "boolean"
                     },
-                    "rust-analyzer.lens.methodReferences": {
+                    "rust-analyzer.lens.references.adt.enable": {
+                      "default": false,
+                      "markdownDescription": "Whether to show `References` lens for Struct, Enum, and Union.\nOnly applies when `#rust-analyzer.lens.enable#` is set.",
+                      "type": "boolean"
+                    },
+                    "rust-analyzer.lens.references.enumVariant.enable": {
+                      "default": false,
+                      "markdownDescription": "Whether to show `References` lens for Enum Variants.\nOnly applies when `#rust-analyzer.lens.enable#` is set.",
+                      "type": "boolean"
+                    },
+                    "rust-analyzer.lens.references.method.enable": {
                       "default": false,
                       "markdownDescription": "Whether to show `Method References` lens. Only applies when\n`#rust-analyzer.lens.enable#` is set.",
                       "type": "boolean"
                     },
-                    "rust-analyzer.lens.references": {
+                    "rust-analyzer.lens.references.trait.enable": {
                       "default": false,
-                      "markdownDescription": "Whether to show `References` lens for Struct, Enum, Union and Trait.\nOnly applies when `#rust-analyzer.lens.enable#` is set.",
+                      "markdownDescription": "Whether to show `References` lens for Trait.\nOnly applies when `#rust-analyzer.lens.enable#` is set.",
                       "type": "boolean"
                     },
-                    "rust-analyzer.lens.run": {
+                    "rust-analyzer.lens.run.enable": {
                       "default": true,
                       "markdownDescription": "Whether to show `Run` lens. Only applies when\n`#rust-analyzer.lens.enable#` is set.",
                       "type": "boolean"
@@ -542,7 +683,7 @@
                       "markdownDescription": "Disable project auto-discovery in favor of explicitly specified set\nof projects.\n\nElements must be paths pointing to `Cargo.toml`,\n`rust-project.json`, or JSON objects in `rust-project.json` format.",
                       "type": "array"
                     },
-                    "rust-analyzer.lruCapacity": {
+                    "rust-analyzer.lru.capacity": {
                       "default": null,
                       "markdownDescription": "Number of syntax trees rust-analyzer keeps in memory. Defaults to 128.",
                       "minimum": 0,
@@ -556,9 +697,14 @@
                       "markdownDescription": "Whether to show `can't find Cargo.toml` error message.",
                       "type": "boolean"
                     },
+                    "rust-analyzer.procMacro.attributes.enable": {
+                      "default": true,
+                      "markdownDescription": "Expand attribute macros. Requires `#rust-analyzer.procMacro.enable#` to be set.",
+                      "type": "boolean"
+                    },
                     "rust-analyzer.procMacro.enable": {
                       "default": true,
-                      "markdownDescription": "Enable support for procedural macros, implies `#rust-analyzer.cargo.runBuildScripts#`.",
+                      "markdownDescription": "Enable support for procedural macros, implies `#rust-analyzer.cargo.buildScripts.enable#`.",
                       "type": "boolean"
                     },
                     "rust-analyzer.procMacro.ignored": {
@@ -573,6 +719,11 @@
                         "null",
                         "string"
                       ]
+                    },
+                    "rust-analyzer.restartServerOnConfigChange": {
+                      "default": false,
+                      "markdownDescription": "Whether to restart the server automatically when certain settings that require a restart are changed.",
+                      "type": "boolean"
                     },
                     "rust-analyzer.runnableEnv": {
                       "anyOf": [
@@ -603,15 +754,7 @@
                       "default": null,
                       "markdownDescription": "Environment variables passed to the runnable launched using `Test` or `Debug` lens or `rust-analyzer.run` command."
                     },
-                    "rust-analyzer.runnables.cargoExtraArgs": {
-                      "default": [],
-                      "items": {
-                        "type": "string"
-                      },
-                      "markdownDescription": "Additional arguments to be passed to cargo for runnables such as\ntests or binaries. For example, it may be `--release`.",
-                      "type": "array"
-                    },
-                    "rust-analyzer.runnables.overrideCargo": {
+                    "rust-analyzer.runnables.command": {
                       "default": null,
                       "markdownDescription": "Command to be executed instead of 'cargo' for runnables.",
                       "type": [
@@ -619,18 +762,21 @@
                         "string"
                       ]
                     },
-                    "rust-analyzer.rustcSource": {
+                    "rust-analyzer.runnables.extraArgs": {
+                      "default": [],
+                      "items": {
+                        "type": "string"
+                      },
+                      "markdownDescription": "Additional arguments to be passed to cargo for runnables such as\ntests or binaries. For example, it may be `--release`.",
+                      "type": "array"
+                    },
+                    "rust-analyzer.rustc.source": {
                       "default": null,
                       "markdownDescription": "Path to the Cargo.toml of the rust compiler workspace, for usage in rustc_private\nprojects, or \"discover\" to try to automatically find it if the `rustc-dev` component\nis installed.\n\nAny project which uses rust-analyzer with the rustcPrivate\ncrates must set `[package.metadata.rust-analyzer] rustc_private=true` to use it.\n\nThis option does not take effect until rust-analyzer is restarted.",
                       "type": [
                         "null",
                         "string"
                       ]
-                    },
-                    "rust-analyzer.rustfmt.enableRangeFormatting": {
-                      "default": false,
-                      "markdownDescription": "Enables the use of rustfmt's unstable range formatting command for the\n`textDocument/rangeFormatting` request. The rustfmt option is unstable and only\navailable on a nightly build.",
-                      "type": "boolean"
                     },
                     "rust-analyzer.rustfmt.extraArgs": {
                       "default": [],
@@ -651,6 +797,116 @@
                         "array"
                       ]
                     },
+                    "rust-analyzer.rustfmt.rangeFormatting.enable": {
+                      "default": false,
+                      "markdownDescription": "Enables the use of rustfmt's unstable range formatting command for the\n`textDocument/rangeFormatting` request. The rustfmt option is unstable and only\navailable on a nightly build.",
+                      "type": "boolean"
+                    },
+                    "rust-analyzer.semanticHighlighting.doc.comment.inject.enable": {
+                      "default": true,
+                      "markdownDescription": "Inject additional highlighting into doc comments.\n\nWhen enabled, rust-analyzer will highlight rust source in doc comments as well as intra\ndoc links.",
+                      "type": "boolean"
+                    },
+                    "rust-analyzer.semanticHighlighting.operator.enable": {
+                      "default": true,
+                      "markdownDescription": "Use semantic tokens for operators.\n\nWhen disabled, rust-analyzer will emit semantic tokens only for operator tokens when\nthey are tagged with modifiers.",
+                      "type": "boolean"
+                    },
+                    "rust-analyzer.semanticHighlighting.operator.specialization.enable": {
+                      "default": false,
+                      "markdownDescription": "Use specialized semantic tokens for operators.\n\nWhen enabled, rust-analyzer will emit special token types for operator tokens instead\nof the generic `operator` token type.",
+                      "type": "boolean"
+                    },
+                    "rust-analyzer.semanticHighlighting.punctuation.enable": {
+                      "default": false,
+                      "markdownDescription": "Use semantic tokens for punctuations.\n\nWhen disabled, rust-analyzer will emit semantic tokens only for punctuation tokens when\nthey are tagged with modifiers or have a special role.",
+                      "type": "boolean"
+                    },
+                    "rust-analyzer.semanticHighlighting.punctuation.separate.macro.bang": {
+                      "default": false,
+                      "markdownDescription": "When enabled, rust-analyzer will emit a punctuation semantic token for the `!` of macro\ncalls.",
+                      "type": "boolean"
+                    },
+                    "rust-analyzer.semanticHighlighting.punctuation.specialization.enable": {
+                      "default": false,
+                      "markdownDescription": "Use specialized semantic tokens for punctuations.\n\nWhen enabled, rust-analyzer will emit special token types for punctuation tokens instead\nof the generic `punctuation` token type.",
+                      "type": "boolean"
+                    },
+                    "rust-analyzer.semanticHighlighting.strings.enable": {
+                      "default": true,
+                      "markdownDescription": "Use semantic tokens for strings.\n\nIn some editors (e.g. vscode) semantic tokens override other highlighting grammars.\nBy disabling semantic tokens for strings, other grammars can be used to highlight\ntheir contents.",
+                      "type": "boolean"
+                    },
+                    // "rust-analyzer.server.extraEnv": {
+                    //   "additionalProperties": {
+                    //     "type": [
+                    //       "string",
+                    //       "number"
+                    //     ]
+                    //   },
+                    //   "default": null,
+                    //   "markdownDescription": "Extra environment variables that will be passed to the rust-analyzer executable. Useful for passing e.g. `RA_LOG` for debugging.",
+                    //   "type": [
+                    //     "null",
+                    //     "object"
+                    //   ]
+                    // },
+                    // "rust-analyzer.server.path": {
+                    //   "default": null,
+                    //   "markdownDescription": "Path to rust-analyzer executable (points to bundled binary by default).",
+                    //   "type": [
+                    //     "null",
+                    //     "string"
+                    //   ]
+                    // },
+                    "rust-analyzer.signatureInfo.detail": {
+                      "default": "full",
+                      "enum": [
+                        "full",
+                        "parameters"
+                      ],
+                      "enumDescriptions": [
+                        "Show the entire signature.",
+                        "Show only the parameters."
+                      ],
+                      "markdownDescription": "Show full signature of the callable. Only shows parameters if disabled.",
+                      "type": "string"
+                    },
+                    "rust-analyzer.signatureInfo.documentation.enable": {
+                      "default": true,
+                      "markdownDescription": "Show documentation.",
+                      "type": "boolean"
+                    },
+                    // "rust-analyzer.trace.extension": {
+                    //   "default": false,
+                    //   "description": "Enable logging of VS Code extensions itself.",
+                    //   "type": "boolean"
+                    // },
+                    // "rust-analyzer.trace.server": {
+                    //   "default": "off",
+                    //   "description": "Trace requests to the rust-analyzer (this is usually overly verbose and not recommended for regular users).",
+                    //   "enum": [
+                    //     "off",
+                    //     "messages",
+                    //     "verbose"
+                    //   ],
+                    //   "enumDescriptions": [
+                    //     "No traces",
+                    //     "Error only",
+                    //     "Full log"
+                    //   ],
+                    //   "type": "string"
+                    // },
+                    "rust-analyzer.typing.autoClosingAngleBrackets.enable": {
+                      "default": false,
+                      "markdownDescription": "Whether to insert closing angle brackets when typing an opening angle bracket of a generic argument list.",
+                      "type": "boolean"
+                    },
+                    "rust-analyzer.typing.continueCommentsOnNewline": {
+                      "default": true,
+                      "markdownDescription": "Whether to prefix newlines after comments with the corresponding comment prefix.",
+                      "type": "boolean"
+                    },
                     "rust-analyzer.workspace.symbol.search.kind": {
                       "default": "only_types",
                       "enum": [
@@ -658,11 +914,17 @@
                         "all_symbols"
                       ],
                       "enumDescriptions": [
-                        "Search for types only",
-                        "Search for all symbols kinds"
+                        "Search for types only.",
+                        "Search for all symbols kinds."
                       ],
                       "markdownDescription": "Workspace symbol search kind.",
                       "type": "string"
+                    },
+                    "rust-analyzer.workspace.symbol.search.limit": {
+                      "default": 128,
+                      "markdownDescription": "Limits the number of items returned from a workspace symbol search (Defaults to 128).\nSome clients like vs-code issue new searches on result filtering and don't require all results to be returned in the initial search.\nOther clients requires all results upfront and might require a higher limit.",
+                      "minimum": 0,
+                      "type": "integer"
                     },
                     "rust-analyzer.workspace.symbol.search.scope": {
                       "default": "workspace",
@@ -671,8 +933,8 @@
                         "workspace_and_dependencies"
                       ],
                       "enumDescriptions": [
-                        "Search in current workspace only",
-                        "Search in current workspace and dependencies"
+                        "Search in current workspace only.",
+                        "Search in current workspace and dependencies."
                       ],
                       "markdownDescription": "Workspace symbol search scope.",
                       "type": "string"


### PR DESCRIPTION
Went through new options and disabled/removed some that are clearly handled only in the extension but it might be that I've missed some other.

Resolves #73