### PR TITLE
Show error if executable missing pre-opening Terminus

### DIFF
--- a/plugin.py
+++ b/plugin.py
@@ -102,7 +102,7 @@ def open_runnables_in_terminus(window: Optional[sublime.Window], runnables: List
         command_to_run = [cargo_path] + args["cargoArgs"]
         if not shutil.which(command_to_run[0]):
             sublime.error_message(
-                'Cannot run executable "{}". You need to make sure that it is in the PATH.'.format(command_to_run[0]))
+                'Cannot run executable "{}". Ensure that it is in the PATH of the Sublime Text process.'.format(command_to_run[0]))
             return
         if args["cargoExtraArgs"]:
             command_to_run += args["cargoExtraArgs"]

--- a/plugin.py
+++ b/plugin.py
@@ -100,6 +100,10 @@ def open_runnables_in_terminus(window: Optional[sublime.Window], runnables: List
         else:
             cargo_path = 'cargo'
         command_to_run = [cargo_path] + args["cargoArgs"]
+        if not shutil.which(command_to_run[0]):
+            sublime.error_message(
+                'Cannot run executable "{}". You need to make sure that it is in the PATH.'.format(command_to_run[0]))
+            return
         if args["cargoExtraArgs"]:
             command_to_run += args["cargoExtraArgs"]
         if args["executableArgs"]:


### PR DESCRIPTION
Improve user experience when executable is missing and which would cause Terminus to die with no feedback in the UI.

Resolves #84