### PR TITLE
chore: update rust-analyzer to 2023-01-30

### DIFF
--- a/LSP-rust-analyzer.sublime-settings
+++ b/LSP-rust-analyzer.sublime-settings
@@ -274,8 +274,6 @@
 		"rust-analyzer.inlayHints.lifetimeElisionHints.enable": "never",
 		// Whether to prefer using parameter names as the name for elided lifetime hints if possible.
 		"rust-analyzer.inlayHints.lifetimeElisionHints.useParameterNames": false,
-		// Whether to use location links for parts of type mentioned in inlay hints.
-		"rust-analyzer.inlayHints.locationLinks": true,
 		// Maximum length for inlay hints. Set to null to have an unlimited length.
 		"rust-analyzer.inlayHints.maxLength": 25,
 		// Whether to show function parameter name inlay hints at the call site.

--- a/plugin.py
+++ b/plugin.py
@@ -33,7 +33,9 @@ SESSION_NAME = "rust-analyzer"
 # Update this single git tag to download a newer version.
 # After changing this tag, go through the server settings again to see
 # if any new server settings are added or old ones removed.
-TAG = "2023-01-16"
+# Compare the previous and new tags's editors/code/package.json with
+# https://github.com/rust-lang/rust-analyzer/compare/2023-01-16...2023-01-30
+TAG = "2023-01-30"
 
 URL = "https://github.com/rust-analyzer/rust-analyzer/releases/download/{tag}/rust-analyzer-{arch}-{platform}.gz"
 


### PR DESCRIPTION
- remove `rust-analyzer.inlayHints.locationLinks` to match upstream
- add a reminder for the fastest way to list server settings changes