### PR TITLE
Update Rust Analyzer to 2023-05-15

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 images/ export-ignore
+scripts/ export-ignore

--- a/LSP-rust-analyzer.sublime-settings
+++ b/LSP-rust-analyzer.sublime-settings
@@ -52,6 +52,12 @@
 		// Extra environment variables that will be set when running cargo,
 		// rustc or other commands within the workspace. Useful for setting RUSTFLAGS.
 		"rust-analyzer.cargo.extraEnv": {},
+		// Extra arguments that are passed to every cargo invocation.
+		//
+		// ```json
+		// "rust-analyzer.cargo.extraArgs": ["--all-features"],
+		// ```
+		"rust-analyzer.cargo.extraArgs": [],
 		// List of features to activate.
 		// Set this to `"all"` to pass `--all-features` to cargo.
 		"rust-analyzer.cargo.features": [],
@@ -60,6 +66,13 @@
 		// Relative path to the sysroot, or "discover" to try to automatically find
 		// it via "rustc --print sysroot". Unsetting this disables sysroot loading.
 		"rust-analyzer.cargo.sysroot": "discover",
+		// Relative path to the sysroot library sources. If left unset, this will default to
+		// `{cargo.sysroot}/lib/rustlib/src/rust/library`.
+		//
+		// ```json
+		// "rust-analyzer.cargo.sysrootSrc": "/home/user/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library",
+		// ```
+		"rust-analyzer.cargo.sysrootSrc": null,
 		// Compilation target override (target triple).
 		"rust-analyzer.cargo.target": null,
 		// Unsets `#[cfg(test)]` for the specified crates.
@@ -128,6 +141,14 @@
 		// Whether to add parenthesis and argument snippets when completing function.
 		// possible values: fill_arguments, add_parentheses, none
 		"rust-analyzer.completion.callable.snippets": "fill_arguments",
+		// Maximum number of completions to return. If `null`, the limit is infinite.
+		//
+		// For a maximum of 5, use:
+		//
+		// ```json
+		// "rust-analyzer.completion.limit": 5,
+		// ```
+		"rust-analyzer.completion.limit": null,
 		// Whether to show postfix snippets like `dbg`, `if`, `not`, etc.
 		"rust-analyzer.completion.postfix.enable": true,
 		// Enables completions of private items and fields that are defined in the current workspace even if they are not visible

--- a/LSP-rust-analyzer.sublime-settings
+++ b/LSP-rust-analyzer.sublime-settings
@@ -225,6 +225,8 @@
 		"rust-analyzer.files.watcher": "client",
 		// Enables highlighting of related references while the cursor is on `break`, `loop`, `while`, or `for` keywords.
 		"rust-analyzer.highlightRelated.breakPoints.enable": true,
+		// Enables highlighting of all captures of a closure while the cursor is on the `|` or move keyword of a closure.
+		"rust-analyzer.highlightRelated.closureCaptures.enable": true,
 		// Enables highlighting of all exit points while the cursor is on any `return`, `?`, `fn`, or return type arrow (`->`).
 		"rust-analyzer.highlightRelated.exitPoints.enable": true,
 		// Enables highlighting of related references while the cursor is on any identifier.
@@ -254,8 +256,10 @@
 		// Whether to show keyword hover popups. Only applies when
 		// `#rust-analyzer.hover.documentation.enable#` is set.
 		"rust-analyzer.hover.documentation.keywords.enable": true,
-		// Use markdown syntax for links in hover.
+		// Use markdown syntax for links on hover.
 		"rust-analyzer.hover.links.enable": true,
+		// Whether to show memory layout data on hover.
+		"rust-analyzer.hover.memoryLayout.enable": true,
 		// Whether to enforce the import granularity setting for all files. If set to false rust-analyzer will try to keep import
 		// styles consistent per file.
 		"rust-analyzer.imports.granularity.enforce": false,
@@ -281,9 +285,13 @@
 		// Minimum number of lines required before the `}` until the hint is shown (set to 0 or 1
 		// to always show them).
 		"rust-analyzer.inlayHints.closingBraceHints.minLines": 25,
+		// Whether to show inlay hints for closure captures.
+		"rust-analyzer.inlayHints.closureCaptureHints.enable": false,
 		// Whether to show inlay type hints for return types of closures.
 		// possible values: always, never, with_block
 		"rust-analyzer.inlayHints.closureReturnTypeHints.enable": "never",
+		// Closure notation in type and chaining inlay hints.
+		"rust-analyzer.inlayHints.closureStyle": "impl_fn",
 		// Whether to show enum variant discriminant hints.
 		"rust-analyzer.inlayHints.discriminantHints.enable": "never",
 		// Whether to show inlay hints for type adjustments.
@@ -313,6 +321,8 @@
 		"rust-analyzer.inlayHints.typeHints.hideClosureInitialization": false,
 		// Whether to hide inlay type hints for constructors.
 		"rust-analyzer.inlayHints.typeHints.hideNamedConstructor": false,
+		// Enables the experimental support for interpreting tests.
+		"rust-analyzer.interpret.tests": false,
 		// Join lines merges consecutive declaration and initialization of an assignment.
 		"rust-analyzer.joinLines.joinAssignments": true,
 		// Join lines inserts else between consecutive ifs.
@@ -356,6 +366,8 @@
 		"rust-analyzer.linkedProjects": [],
 		// Number of syntax trees rust-analyzer keeps in memory. Defaults to 128.
 		"rust-analyzer.lru.capacity": null,
+		// Sets the LRU capacity of the specified queries.
+		"rust-analyzer.lru.query.capacities": {},
 		// Whether to show `can't find Cargo.toml` error message.
 		"rust-analyzer.notifications.cargoTomlNotFound": true,
 		// How many worker threads in the main loop. The default `null` means to pick automatically.
@@ -367,8 +379,7 @@
 		// These proc-macros will be ignored when trying to expand them.
 		// This config takes a map of crate names with the exported proc-macro names to ignore as values.
 		"rust-analyzer.procMacro.ignored": {},
-		// Internal config, path to proc-macro server executable (typically,
-		// this is rust-analyzer itself, but we override this in tests).
+		// Internal config, path to proc-macro server executable.
 		"rust-analyzer.procMacro.server": null,
 		// Exclude imports from find-all-references.
 		"rust-analyzer.references.excludeImports": false,
@@ -390,8 +401,9 @@
 		"rust-analyzer.rustc.source": null,
 		// Additional arguments to `rustfmt`.
 		"rust-analyzer.rustfmt.extraArgs": [],
-		// Advanced option, fully override the command rust-analyzer uses for
-		// formatting.
+		// Advanced option, fully override the command rust-analyzer uses for formatting. This should be the equivalent
+		// of `rustfmt` here, and not that of `cargo fmt`. The file contents will be passed on the standard input and
+		// the formatted result will be read from the standard output.
 		"rust-analyzer.rustfmt.overrideCommand": null,
 		// Enables the use of rustfmt's unstable range formatting command for the
 		// `textDocument/rangeFormatting` request. The rustfmt option is unstable and only
@@ -401,6 +413,8 @@
 		// When enabled, rust-analyzer will highlight rust source in doc comments as well as intra
 		// doc links.
 		"rust-analyzer.semanticHighlighting.doc.comment.inject.enable": true,
+		// Whether the server is allowed to emit non-standard tokens and modifiers.
+		"rust-analyzer.semanticHighlighting.nonStandardTokens": true,
 		// Use semantic tokens for operators.
 		// When disabled, rust-analyzer will emit semantic tokens only for operator tokens when
 		// they are tagged with modifiers.
@@ -409,14 +423,14 @@
 		// When enabled, rust-analyzer will emit special token types for operator tokens instead
 		// of the generic `operator` token type.
 		"rust-analyzer.semanticHighlighting.operator.specialization.enable": false,
-		// Use semantic tokens for punctuations.
+		// Use semantic tokens for punctuation.
 		// When disabled, rust-analyzer will emit semantic tokens only for punctuation tokens when
 		// they are tagged with modifiers or have a special role.
 		"rust-analyzer.semanticHighlighting.punctuation.enable": false,
 		// When enabled, rust-analyzer will emit a punctuation semantic token for the `!` of macro
 		// calls.
 		"rust-analyzer.semanticHighlighting.punctuation.separate.macro.bang": false,
-		// Use specialized semantic tokens for punctuations.
+		// Use specialized semantic tokens for punctuation.
 		// When enabled, rust-analyzer will emit special token types for punctuation tokens instead
 		// of the generic `punctuation` token type.
 		"rust-analyzer.semanticHighlighting.punctuation.specialization.enable": false,

--- a/LSP-rust-analyzer.sublime-settings
+++ b/LSP-rust-analyzer.sublime-settings
@@ -114,9 +114,11 @@
 		// ```
 		// .
 		"rust-analyzer.check.overrideCommand": null,
-		// Check for a specific target. Defaults to
-		// `#rust-analyzer.cargo.target#`.
-		"rust-analyzer.check.target": null,
+		// Check for a specific target. Defaults to `#rust-analyzer.cargo.target#`.
+		//
+		// Can be a single target, e.g. `\"x86_64-unknown-linux-gnu\"` or a list of targets, e.g.
+		//`[\"aarch64-apple-darwin\", \"x86_64-apple-darwin\"]`
+		"rust-analyzer.check.targets": null,
 		// Toggles the additional completions that automatically add imports when completed.
 		// Note that your client must specify the `additionalTextEdits` LSP client capability to truly have this feature enabled.
 		"rust-analyzer.completion.autoimport.enable": true,

--- a/plugin.py
+++ b/plugin.py
@@ -208,6 +208,9 @@ class RustAnalyzer(AbstractPlugin):
                 return True
             elif command_name == "rust-analyzer.showReferences":
                 return self._handle_show_references(session, command, done_callback)
+            elif command_name == "rust-analyzer.triggerParameterHints":
+                done_callback()
+                return True
             else:
                 return False
         except Exception as ex:

--- a/plugin.py
+++ b/plugin.py
@@ -30,34 +30,17 @@ except ImportError:
 
 SESSION_NAME = "rust-analyzer"
 
-# Update this single git tag to download a newer version.
-# After changing this tag, go through the server settings again to see
-# if any new server settings are added or old ones removed.
-# Compare the previous and new tags's editors/code/package.json with
-# https://github.com/rust-lang/rust-analyzer/compare/2023-01-30...2023-04-04
-#
-# The following script finds the keys that are in the `rust-analyzer`
-# package.json, but not in `LSP-rust-analyzer`'s sublime-settings.
-#
-# ```bash
-# lsp_ra_repo=/path/to/sublimelsp/LSP-rust-analyzer
-# ra_repo=/path/to/rust-analyzer/rust-analyzer
-#
-# lsp_ra_settings=$(rg -o '"rust-analyzer.([^"]+)"' "${lsp_ra_repo}/LSP-rust-analyzer.sublime-settings" | sort)
-# ra_settings=$(jq '.contributes.configuration.properties
-#         | to_entries
-#         | map(.key)
-#         | .[] | select(. != "$generated-start" and . != "$generated-end")' \
-#         "${ra_repo}/editors/code/package.json" | sort)
-#
-# # Missing settings in LSP-rust-analyzer
-# rg -vf <(echo "${lsp_ra_settings}") <(echo "${ra_settings}")
-#
-# # Settings in LSP-rust-analyzer that are no longer relevant
-# rg -vf <(echo "${ra_settings}") <(echo "${lsp_ra_settings}") \
-#     | rg -v 'terminusAutoClose|terminusUsePanel'
-# ```
-TAG = "2023-04-04"
+TAG = "2023-05-15"
+"""
+Update this single git tag to download a newer version.
+After changing this tag, go through the server settings again to see
+if any new server settings are added or old ones removed.
+Compare the previous and new tags's editors/code/package.json with
+https://github.com/rust-lang/rust-analyzer/compare/2023-01-30...2023-05-15
+
+The script in `./scripts/new_settings.sh can be used to find the keys that are in the `rust-analyzer`
+package.json, but not in `LSP-rust-analyzer`'s sublime-settings.
+"""
 
 URL = "https://github.com/rust-analyzer/rust-analyzer/releases/download/{tag}/rust-analyzer-{arch}-{platform}.gz"
 

--- a/plugin.py
+++ b/plugin.py
@@ -34,8 +34,30 @@ SESSION_NAME = "rust-analyzer"
 # After changing this tag, go through the server settings again to see
 # if any new server settings are added or old ones removed.
 # Compare the previous and new tags's editors/code/package.json with
-# https://github.com/rust-lang/rust-analyzer/compare/2023-01-16...2023-01-30
-TAG = "2023-01-30"
+# https://github.com/rust-lang/rust-analyzer/compare/2023-01-30...2023-04-04
+#
+# The following script finds the keys that are in the `rust-analyzer`
+# package.json, but not in `LSP-rust-analyzer`'s sublime-settings.
+#
+# ```bash
+# lsp_ra_repo=/path/to/sublimelsp/LSP-rust-analyzer
+# ra_repo=/path/to/rust-analyzer/rust-analyzer
+#
+# lsp_ra_settings=$(rg -o '"rust-analyzer.([^"]+)"' "${lsp_ra_repo}/LSP-rust-analyzer.sublime-settings" | sort)
+# ra_settings=$(jq '.contributes.configuration.properties
+#         | to_entries
+#         | map(.key)
+#         | .[] | select(. != "$generated-start" and . != "$generated-end")' \
+#         "${ra_repo}/editors/code/package.json" | sort)
+#
+# # Missing settings in LSP-rust-analyzer
+# rg -vf <(echo "${lsp_ra_settings}") <(echo "${ra_settings}")
+#
+# # Settings in LSP-rust-analyzer that are no longer relevant
+# rg -vf <(echo "${ra_settings}") <(echo "${lsp_ra_settings}") \
+#     | rg -v 'terminusAutoClose|terminusUsePanel'
+# ```
+TAG = "2023-04-04"
 
 URL = "https://github.com/rust-analyzer/rust-analyzer/releases/download/{tag}/rust-analyzer-{arch}-{platform}.gz"
 

--- a/scripts/new_settings.sh
+++ b/scripts/new_settings.sh
@@ -8,7 +8,12 @@ set -e
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 LSP_REPO_DIR="$SCRIPT_DIR/.."
-RA_REPO_DIR=/usr/local/workspace/github/rust-analyzer/
+
+read -rp 'Provide directory path to the rust-analyzer repository (for example: /usr/local/github/rust-analyzer/): ' RA_REPO_DIR
+if [ ! -d "$RA_REPO_DIR" ]; then
+   echo "Directory path '$RA_REPO_DIR' DOES NOT exist."
+   exit
+fi
 
 lsp_ra_settings=$(rg -o '"rust-analyzer.([^"]+)"' "${LSP_REPO_DIR}/LSP-rust-analyzer.sublime-settings" | sort)
 ra_settings=$(jq '.contributes.configuration.properties

--- a/scripts/new_settings.sh
+++ b/scripts/new_settings.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+# The following script finds the keys that are in the `rust-analyzer`
+# package.json, but not in `LSP-rust-analyzer`'s sublime-settings.
+
+# exit when any command fails
+set -e
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+LSP_REPO_DIR="$SCRIPT_DIR/.."
+RA_REPO_DIR=/usr/local/workspace/github/rust-analyzer/
+
+lsp_ra_settings=$(rg -o '"rust-analyzer.([^"]+)"' "${LSP_REPO_DIR}/LSP-rust-analyzer.sublime-settings" | sort)
+ra_settings=$(jq '.contributes.configuration.properties
+        | to_entries
+        | map(.key)
+        | .[] | select(. != "$generated-start" and . != "$generated-end")' \
+        "${RA_REPO_DIR}/editors/code/package.json" | sort)
+
+# Missing settings in LSP-rust-analyzer
+rg -vf <(echo "${lsp_ra_settings}") <(echo "${ra_settings}")
+
+# Settings in LSP-rust-analyzer that are no longer relevant
+rg -vf <(echo "${ra_settings}") <(echo "${lsp_ra_settings}") \
+   | rg -v 'terminusAutoClose|terminusUsePanel'

--- a/sublime-package.json
+++ b/sublime-package.json
@@ -113,6 +113,11 @@
                       "markdownDescription": "Use `RUSTC_WRAPPER=rust-analyzer` when running build scripts to\navoid checking unnecessary things.",
                       "type": "boolean"
                     },
+                    "rust-analyzer.cargo.extraArgs": {
+                      "default": [],
+                      "markdownDescription": "Extra arguments that are passed to every cargo invocation.",
+                      "type": "array"
+                    },
                     "rust-analyzer.cargo.extraEnv": {
                       "default": {},
                       "markdownDescription": "Extra environment variables that will be set when running cargo, rustc\nor other commands within the workspace. Useful for setting RUSTFLAGS.",
@@ -146,10 +151,19 @@
                     },
                     "rust-analyzer.cargo.sysroot": {
                       "default": "discover",
-                      "markdownDescription": "Relative path to the sysroot, or \"discover\" to try to automatically find it via\n\"rustc --print sysroot\".\n\nUnsetting this disables sysroot loading.\n\nThis option does not take effect until rust-analyzer is restarted.",                      "type": [
+                      "markdownDescription": "Relative path to the sysroot, or \"discover\" to try to automatically find it via\n\"rustc --print sysroot\".\n\nUnsetting this disables sysroot loading.\n\nThis option does not take effect until rust-analyzer is restarted.",
+                      "type": [
                         "null",
                         "string"
                       ]
+                    },
+                    "rust-analyzer.cargo.sysrootSrc": {
+                        "markdownDescription": "Relative path to the sysroot library sources. If left unset, this will default to\n`{cargo.sysroot}/lib/rustlib/src/rust/library`.\n\nThis option does not take effect until rust-analyzer is restarted.",
+                        "default": null,
+                        "type": [
+                            "null",
+                            "string"
+                        ]
                     },
                     "rust-analyzer.cargo.target": {
                       "default": null,
@@ -307,6 +321,11 @@
                       ],
                       "markdownDescription": "Whether to add parenthesis and argument snippets when completing function.",
                       "type": "string"
+                    },
+                    "rust-analyzer.completion.limit": {
+                      "default": true,
+                      "markdownDescription": "Maximum number of completions to return. If `null`, the limit is infinite.",
+                      "type": "number"
                     },
                     "rust-analyzer.completion.postfix.enable": {
                       "default": true,

--- a/sublime-package.json
+++ b/sublime-package.json
@@ -42,7 +42,7 @@
                         "todo",
                         "default"
                       ],
-                      "enumDescriptions": [
+                      "markdownEnumDescriptions": [
                         "Fill missing expressions with the `todo` macro",
                         "Fill missing expressions with reasonable defaults, `new` or `default` constructors."
                       ],
@@ -129,7 +129,7 @@
                           "enum": [
                             "all"
                           ],
-                          "enumDescriptions": [
+                          "markdownEnumDescriptions": [
                             "Pass `--all-features` to cargo"
                           ],
                           "type": "string"
@@ -207,12 +207,12 @@
                       "type": "string"
                     },
                     "rust-analyzer.check.extraArgs": {
-                      "default": [],
-                      "items": {
-                        "type": "string"
-                      },
                       "markdownDescription": "Extra arguments for `cargo check`.",
-                      "type": "array"
+                      "default": [],
+                      "type": "array",
+                      "items": {
+                          "type": "string"
+                      }
                     },
                     "rust-analyzer.check.extraEnv": {
                       "default": {},
@@ -225,7 +225,7 @@
                           "enum": [
                             "all"
                           ],
-                          "enumDescriptions": [
+                          "markdownEnumDescriptions": [
                             "Pass `--all-features` to cargo"
                           ],
                           "type": "string"
@@ -249,7 +249,7 @@
                         "root",
                         "workspace"
                       ],
-                      "enumDescriptions": [
+                      "markdownEnumDescriptions": [
                         "Run checks in the project’s root directory.",
                         "Run checks for workspaces in the corresponding workspaces' root directories. This falls back to `root` if rust-analyzer.cargo.checkOnSave.invocationStrategy is set to `once`."
                       ],
@@ -325,7 +325,11 @@
                     "rust-analyzer.completion.limit": {
                       "default": true,
                       "markdownDescription": "Maximum number of completions to return. If `null`, the limit is infinite.",
-                      "type": "number"
+                      "type": [
+                          "null",
+                          "integer"
+                      ],
+                      "minimum": 0
                     },
                     "rust-analyzer.completion.postfix.enable": {
                       "default": true,
@@ -489,6 +493,11 @@
                       "markdownDescription": "Enables highlighting of related references while the cursor is on `break`, `loop`, `while`, or `for` keywords.",
                       "type": "boolean"
                     },
+                    "rust-analyzer.highlightRelated.closureCaptures.enable": {
+                        "markdownDescription": "Enables highlighting of all captures of a closure while the cursor is on the `|` or move keyword of a closure.",
+                        "default": true,
+                        "type": "boolean"
+                    },
                     "rust-analyzer.highlightRelated.exitPoints.enable": {
                       "default": true,
                       "markdownDescription": "Enables highlighting of all exit points while the cursor is on any `return`, `?`, `fn`, or return type arrow (`->`).",
@@ -546,8 +555,13 @@
                     },
                     "rust-analyzer.hover.links.enable": {
                       "default": true,
-                      "markdownDescription": "Use markdown syntax for links in hover.",
+                      "markdownDescription": "Use markdown syntax for links on hover.",
                       "type": "boolean"
+                    },
+                    "rust-analyzer.hover.memoryLayout.enable": {
+                        "markdownDescription": "Whether to show memory layout data on hover.",
+                        "default": true,
+                        "type": "boolean"
                     },
                     "rust-analyzer.imports.granularity.enforce": {
                       "default": false,
@@ -593,7 +607,7 @@
                         "self",
                         "crate"
                       ],
-                      "enumDescriptions": [
+                      "markdownEnumDescriptions": [
                         "Insert import paths relative to the current module, using up to one `super` prefix if the parent module contains the requested item.",
                         "Insert import paths relative to the current module, using up to one `super` prefix if the parent module contains the requested item. Prefixes `self` in front of the path if it starts with a module.",
                         "Force import paths to be absolute by always starting them with `crate` or the extern crate name they come from."
@@ -622,6 +636,11 @@
                       "minimum": 0,
                       "type": "integer"
                     },
+                    "rust-analyzer.inlayHints.closureCaptureHints.enable": {
+                        "markdownDescription": "Whether to show inlay hints for closure captures.",
+                        "default": false,
+                        "type": "boolean"
+                    },
                     "rust-analyzer.inlayHints.closureReturnTypeHints.enable": {
                       "default": "never",
                       "enum": [
@@ -636,6 +655,23 @@
                       ],
                       "markdownDescription": "Whether to show inlay type hints for return types of closures.",
                       "type": "string"
+                    },
+                    "rust-analyzer.inlayHints.closureStyle": {
+                        "markdownDescription": "Closure notation in type and chaining inlay hints.",
+                        "default": "impl_fn",
+                        "type": "string",
+                        "enum": [
+                            "impl_fn",
+                            "rust_analyzer",
+                            "with_id",
+                            "hide"
+                        ],
+                        "markdownEnumDescriptions": [
+                            "`impl FnMut(i32, u64) -> i8`",
+                            "`|i32, u64| -> i8`",
+                            "`{closure#14352}`, where that id is the unique number of the closure in r-a internals",
+                            "Shows `...` for every closure type"
+                        ]
                     },
                     "rust-analyzer.inlayHints.discriminantHints.enable": {
                       "markdownDescription": "Whether to show enum variant discriminant hints.",
@@ -682,11 +718,11 @@
                         "prefer_prefix",
                         "prefer_postfix"
                       ],
-                      "enumDescriptions": [
+                      "markdownEnumDescriptions": [
                         "Always show adjustment hints as prefix (`*expr`).",
                         "Always show adjustment hints as postfix (`expr.*`).",
-                        "Show prefix or postfix depending on which uses less parenthesis, prefering prefix.",
-                        "Show prefix or postfix depending on which uses less parenthesis, prefering postfix."
+                        "Show prefix or postfix depending on which uses less parenthesis, preferring prefix.",
+                        "Show prefix or postfix depending on which uses less parenthesis, preferring postfix."
                       ]
                     },
                     "rust-analyzer.inlayHints.lifetimeElisionHints.enable": {
@@ -762,6 +798,11 @@
                       "default": false,
                       "markdownDescription": "Whether to hide inlay type hints for constructors.",
                       "type": "boolean"
+                    },
+                    "rust-analyzer.interpret.tests": {
+                        "markdownDescription": "Enables the experimental support for interpreting tests.",
+                        "default": false,
+                        "type": "boolean"
                     },
                     "rust-analyzer.joinLines.joinAssignments": {
                       "default": true,
@@ -860,6 +901,11 @@
                         "integer"
                       ]
                     },
+                    "rust-analyzer.lru.query.capacities": {
+                        "markdownDescription": "Sets the LRU capacity of the specified queries.",
+                        "default": {},
+                        "type": "object"
+                    },
                     "rust-analyzer.notifications.cargoTomlNotFound": {
                       "default": true,
                       "markdownDescription": "Whether to show `can't find Cargo.toml` error message.",
@@ -891,7 +937,7 @@
                     },
                     "rust-analyzer.procMacro.server": {
                       "default": null,
-                      "markdownDescription": "Internal config, path to proc-macro server executable (typically,\nthis is rust-analyzer itself, but we override this in tests).",
+                      "markdownDescription": "Internal config, path to proc-macro server executable.",
                       "type": [
                         "null",
                         "string"
@@ -973,7 +1019,7 @@
                       "items": {
                         "type": "string"
                       },
-                      "markdownDescription": "Advanced option, fully override the command rust-analyzer uses for\nformatting.",
+                      "markdownDescription": "Advanced option, fully override the command rust-analyzer uses for formatting. This should be the equivalent of `rustfmt` here, and not that of `cargo fmt`. The file contents will be passed on the standard input and the formatted result will be read from the standard output.",
                       "type": [
                         "null",
                         "array"
@@ -989,6 +1035,11 @@
                       "markdownDescription": "Inject additional highlighting into doc comments.\n\nWhen enabled, rust-analyzer will highlight rust source in doc comments as well as intra\ndoc links.",
                       "type": "boolean"
                     },
+                    "rust-analyzer.semanticHighlighting.nonStandardTokens": {
+                        "markdownDescription": "Whether the server is allowed to emit non-standard tokens and modifiers.",
+                        "default": true,
+                        "type": "boolean"
+                    },
                     "rust-analyzer.semanticHighlighting.operator.enable": {
                       "default": true,
                       "markdownDescription": "Use semantic tokens for operators.\n\nWhen disabled, rust-analyzer will emit semantic tokens only for operator tokens when\nthey are tagged with modifiers.",
@@ -1001,7 +1052,7 @@
                     },
                     "rust-analyzer.semanticHighlighting.punctuation.enable": {
                       "default": false,
-                      "markdownDescription": "Use semantic tokens for punctuations.\n\nWhen disabled, rust-analyzer will emit semantic tokens only for punctuation tokens when\nthey are tagged with modifiers or have a special role.",
+                      "markdownDescription": "Use semantic tokens for punctuation.\n\nWhen disabled, rust-analyzer will emit semantic tokens only for punctuation tokens when\nthey are tagged with modifiers or have a special role.",
                       "type": "boolean"
                     },
                     "rust-analyzer.semanticHighlighting.punctuation.separate.macro.bang": {
@@ -1011,7 +1062,7 @@
                     },
                     "rust-analyzer.semanticHighlighting.punctuation.specialization.enable": {
                       "default": false,
-                      "markdownDescription": "Use specialized semantic tokens for punctuations.\n\nWhen enabled, rust-analyzer will emit special token types for punctuation tokens instead\nof the generic `punctuation` token type.",
+                      "markdownDescription": "Use specialized semantic tokens for punctuation.\n\nWhen enabled, rust-analyzer will emit special token types for punctuation tokens instead\nof the generic `punctuation` token type.",
                       "type": "boolean"
                     },
                     "rust-analyzer.semanticHighlighting.strings.enable": {

--- a/sublime-package.json
+++ b/sublime-package.json
@@ -274,12 +274,13 @@
                         "array"
                       ]
                     },
-                    "rust-analyzer.check.target": {
+                    "rust-analyzer.check.targets": {
                       "default": null,
                       "markdownDescription": "Check for a specific target. Defaults to\n`#rust-analyzer.cargo.target#`.",
                       "type": [
                         "null",
-                        "string"
+                        "string",
+                        "array"
                       ]
                     },
                     "rust-analyzer.completion.autoimport.enable": {

--- a/sublime-package.json
+++ b/sublime-package.json
@@ -114,9 +114,12 @@
                       "type": "boolean"
                     },
                     "rust-analyzer.cargo.extraArgs": {
-                      "default": [],
-                      "markdownDescription": "Extra arguments that are passed to every cargo invocation.",
-                      "type": "array"
+                        "markdownDescription": "Extra arguments that are passed to every cargo invocation.",
+                        "default": [],
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "rust-analyzer.cargo.extraEnv": {
                       "default": {},


### PR DESCRIPTION
Heya, the 2023-01-30 version of rust analyzer isn't able to expand proc macros.

I've updated the `rust-analyzer` tag, but haven't gone through all of the settings diff -- I'm not sure how to update `sublime-package.json` (do you copy all of the RA properties as is?).

Sublime also began showing an error message when you code complete `object.method`, because RA now sends a `triggerParameterHints` command. I don't know whether returning `True` is the right thing to do, but it seems to be, based on:

* the [plugin docs](https://github.com/sublimelsp/LSP/blob/43d00544f988f4a415f8fc9569436ff4eb7764d3/plugin/core/sessions.py#L924-L934)
* sublime no longer showed the error message, and inserts the parameter hints