### PR TITLE
feat: implement custom join lines command/keybinding

### DIFF
--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -1,0 +1,9 @@
+[
+    {
+        "keys": ["primary+shift+j"],
+        "command": "rust_analyzer_join_lines",
+        "context": [
+            {"key": "lsp.session_with_name", "operand": "rust-analyzer"}
+        ]
+    },
+]

--- a/LSP-rust-analyzer.sublime-commands
+++ b/LSP-rust-analyzer.sublime-commands
@@ -8,6 +8,10 @@
         }
     },
     {
+        "caption": "LSP-rust-analyzer: Join Lines",
+        "command": "rust_analyzer_join_lines"
+    },
+    {
         "caption": "LSP-rust-analyzer: Open Docs Under Cursor",
         "command": "rust_analyzer_open_docs"
     },

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Select a cargo command from the submenu. This spawns a shell with [Terminus](htt
 
 Joins lines accounting for rust-specific logic.
 
-Also bound to the default join-lines key binding.
+Also bound to the default join-lines key binding (<kbd>ctrl</kbd><kbd>shift</kbd><kbd>j</kbd> or <kbd>command</kbd><kbd>shift</kbd><kbd>j</kbd> on Windows/Linux and Mac respectively).
 
 ### LSP-rust-analyzer: Open Docs Under Cursor
 

--- a/README.md
+++ b/README.md
@@ -49,6 +49,12 @@ Select a cargo command from the submenu. This spawns a shell with [Terminus](htt
 
 ![Example](./images/commands.gif)
 
+### LSP-rust-analyzer: Join Lines
+
+Joins lines accounting for rust-specific logic.
+
+Also bound to the default join-lines key binding.
+
 ### LSP-rust-analyzer: Open Docs Under Cursor
 
 Opens the URL to documentation for the symbol under the cursor, if available.

--- a/plugin_commands.py
+++ b/plugin_commands.py
@@ -1,0 +1,41 @@
+from .plugin import RustAnalyzerCommand
+from LSP.plugin import Request
+from LSP.plugin.core.protocol import Error
+from LSP.plugin.core.protocol import Range
+from LSP.plugin.core.protocol import TextDocumentIdentifier
+from LSP.plugin.core.protocol import TextEdit
+from LSP.plugin.core.typing import List, TypedDict, Union
+from LSP.plugin.core.views import region_to_range
+from LSP.plugin.core.views import text_document_identifier
+from LSP.plugin.formatting import apply_text_edits_to_view
+import sublime
+
+
+class JoinLinesRequest:
+    Type = 'experimental/joinLines'
+    ParamsType = TypedDict('ParamsType', {
+        'textDocument': TextDocumentIdentifier,
+        'ranges': List[Range],
+    })
+    ReturnType = List[TextEdit]
+
+
+class RustAnalyzerJoinLinesCommand(RustAnalyzerCommand):
+
+    def run(self, edit: sublime.Edit) -> None:
+        session = self.session_by_name(self.session_name)
+        if session is None:
+            return
+        params = {
+            'textDocument': text_document_identifier(self.view),
+            'ranges': [region_to_range(self.view, region) for region in self.view.sel()],
+        }  # type: JoinLinesRequest.ParamsType
+        session.send_request(Request(JoinLinesRequest.Type, params), self.on_result_async)
+
+    def on_result_async(self, edits: Union[JoinLinesRequest.ReturnType, Error]) -> None:
+        if isinstance(edits, Error):
+            print('[LSP-rust-analyzer] Error handling the "{}" request. Falling back to native join.')
+            self.view.run_command('join_lines')
+            return
+        if edits:
+            apply_text_edits_to_view(edits, self.view)

--- a/plugin_commands.py
+++ b/plugin_commands.py
@@ -34,7 +34,8 @@ class RustAnalyzerJoinLinesCommand(RustAnalyzerCommand):
 
     def on_result_async(self, edits: Union[JoinLinesRequest.ReturnType, Error]) -> None:
         if isinstance(edits, Error):
-            print('[LSP-rust-analyzer] Error handling the "{}" request. Falling back to native join.')
+            print('[{}] Error handling the "{}" request. Falling back to native join.'.format(
+                self.session_name, JoinLinesRequest.Type))
             self.view.run_command('join_lines')
             return
         if edits:


### PR DESCRIPTION
Just for fun I've implemented handling for one more custom request for joining lines.

It's bound to default join lines key binding but it will fall back to the native one if server is not active or returns an error for some reason.

The placement of the command differs from already implemented commands but I would rather use that approach and convert existing commands to use the same way in the future for more clarity.

Fixes #29