### PR TITLE
feat: support custom command to move item up/down

### DIFF
--- a/LSP-rust-analyzer.sublime-commands
+++ b/LSP-rust-analyzer.sublime-commands
@@ -12,6 +12,16 @@
         "command": "rust_analyzer_join_lines"
     },
     {
+        "caption": "LSP-rust-analyzer: Move Item Down",
+        "command": "rust_analyzer_move_item",
+        "args": {"direction": "Down"}
+    },
+    {
+        "caption": "LSP-rust-analyzer: Move Item Up",
+        "command": "rust_analyzer_move_item",
+        "args": {"direction": "Up"}
+    },
+    {
         "caption": "LSP-rust-analyzer: Open Docs Under Cursor",
         "command": "rust_analyzer_open_docs"
     },

--- a/README.md
+++ b/README.md
@@ -55,6 +55,10 @@ Joins lines accounting for rust-specific logic.
 
 Also bound to the default join-lines key binding (<kbd>ctrl</kbd><kbd>shift</kbd><kbd>j</kbd> or <kbd>command</kbd><kbd>shift</kbd><kbd>j</kbd> on Windows/Linux and Mac respectively).
 
+### LSP-rust-analyzer: Move Item Down / Move Item Up
+
+Moves item under cursor/selection in specified direction.
+
 ### LSP-rust-analyzer: Open Docs Under Cursor
 
 Opens the URL to documentation for the symbol under the cursor, if available.

--- a/plugin_commands.py
+++ b/plugin_commands.py
@@ -105,4 +105,4 @@ class RustAnalyzerMoveItemCommand(RustAnalyzerCommand):
         if not edits:
             sublime.status_message('Did not find anything to move.')
             return
-        apply_text_edits_to_view(edits, self.view, process_snippets=True)
+        apply_text_edits(self.view, edits, process_placeholders=True)

--- a/plugin_commands.py
+++ b/plugin_commands.py
@@ -4,7 +4,8 @@ from LSP.plugin.core.protocol import Error
 from LSP.plugin.core.protocol import Range
 from LSP.plugin.core.protocol import TextDocumentIdentifier
 from LSP.plugin.core.protocol import TextEdit
-from LSP.plugin.core.typing import List, TypedDict, Union
+from LSP.plugin.core.typing import List, Literal, Optional, TypedDict, Union
+from LSP.plugin.core.views import first_selection_region
 from LSP.plugin.core.views import region_to_range
 from LSP.plugin.core.views import text_document_identifier
 from LSP.plugin.formatting import apply_text_edits_to_view
@@ -16,6 +17,17 @@ class JoinLinesRequest:
     ParamsType = TypedDict('ParamsType', {
         'textDocument': TextDocumentIdentifier,
         'ranges': List[Range],
+    })
+    ReturnType = List[TextEdit]
+
+
+class MoveItemRequest:
+    Type = 'experimental/moveItem'
+    Direction = Literal['Up', 'Down']
+    ParamsType = TypedDict('ParamsType', {
+        'textDocument': TextDocumentIdentifier,
+        'range': Range,
+        'direction': Direction,
     })
     ReturnType = List[TextEdit]
 
@@ -48,9 +60,52 @@ class RustAnalyzerJoinLinesCommand(RustAnalyzerCommand):
         if document_version != self.view.change_count():
             return
         if isinstance(edits, Error):
-            print('[{}] Error handling the "{}" request. Falling back to native join.'.format(
-                self.session_name, JoinLinesRequest.Type))
+            sublime.status_message('Error handling the "{}" request. Falling back to native join.'.format(
+                JoinLinesRequest.Type))
             self.view.run_command('join_lines')
             return
         if edits:
             apply_text_edits_to_view(edits, self.view)
+
+
+class RustAnalyzerMoveItemCommand(RustAnalyzerCommand):
+
+    def run(self, edit: sublime.Edit, direction: Optional[MoveItemRequest.Direction] = None) -> None:
+        if direction not in ('Up', 'Down'):
+            sublime.status_message('Error running command: direction must be either "Up" or "Down".')
+            return
+        sublime.set_timeout_async(lambda: self.make_request_async(direction))
+
+    def make_request_async(self, direction: MoveItemRequest.Direction) -> None:
+        session = self.session_by_name(self.session_name)
+        if session is None:
+            return
+        session_view = session.session_view_for_view_async(self.view)
+        if not session_view:
+            return
+        view_listener = session_view.listener()
+        if not view_listener:
+            return
+        first_selection = first_selection_region(self.view)
+        if first_selection is None:
+            return
+        params = {
+            'textDocument': text_document_identifier(self.view),
+            'range': region_to_range(self.view, first_selection),
+            'direction': direction,
+        }  # type: MoveItemRequest.ParamsType
+        request = Request(MoveItemRequest.Type, params)  # type: Request[MoveItemRequest.ReturnType]
+        document_version = self.view.change_count()
+        view_listener.purge_changes_async()
+        session.send_request_task(request).then(lambda result: self.on_result_async(result, document_version))
+
+    def on_result_async(self, edits: Union[MoveItemRequest.ReturnType, Error], document_version: int) -> None:
+        if document_version != self.view.change_count():
+            return
+        if isinstance(edits, Error):
+            sublime.status_message('Error handling the "{}" request.'.format(MoveItemRequest.Type))
+            return
+        if not edits:
+            sublime.status_message('Did not find anything to move.')
+            return
+        apply_text_edits_to_view(edits, self.view, process_snippets=True)


### PR DESCRIPTION
Implement handling for custom request to move item up and down.

Tested with simple case like:

```rust
fn two() {
    println!("Hello, world1!");
}

fn main() {
    println!("Hello, world!");
}
```

and moving `fn`s around.

Note that rust-analyzer returns custom "snippet" text edits. That means that one or more of the edits (in this case one) will include a snippet like `$0` or `${0:foo}`. I'm [implementing opt-in support for that in LSP ](https://github.com/sublimelsp/LSP/pull/2389)which this change depends on.

The point of the snippet is that the cursor position is moved together with moved function/item which otherwise would just stay in the old place.

Based on rust-analyzer extension code:
 - move commands: https://github.com/rust-lang/rust-analyzer/blob/0cd68bfed3e31c034a5ead664ac8ad84d8bc06fd/editors/code/src/commands.ts#L163-L188

Fixes #28