### PR TITLE
fix: use correct rust-analyzer download URL on Windows

### DIFF
--- a/plugin.py
+++ b/plugin.py
@@ -162,23 +162,23 @@ class RustAnalyzer(AbstractPlugin):
             is_windows = sublime.platform() == "windows"
             extension = "zip" if is_windows else "gz"
             url = URL.format(tag=TAG, arch=arch(), platform=platform(), ext=extension)
-            gzipfile = os.path.join(cls.basedir(), f"rust-analyzer.{extension}")
+            archive_file = os.path.join(cls.basedir(), f"rust-analyzer.{extension}")
             serverfile = os.path.join(
                 cls.basedir(),
                 "rust-analyzer.exe" if is_windows else "rust-analyzer"
             )
             with urllib.request.urlopen(url) as fp:
-                with open(gzipfile, "wb") as f:
+                with open(archive_file, "wb") as f:
                     f.write(fp.read())
 
             if is_windows:
-                with zipfile.ZipFile(gzipfile, "r") as zip_ref:
+                with zipfile.ZipFile(archive_file, "r") as zip_ref:
                     zip_ref.extract("rust-analyzer.exe", cls.basedir())
             else:
-                with gzip.open(gzipfile, "rb") as fp:
+                with gzip.open(archive_file, "rb") as fp:
                     with open(serverfile, "wb") as f:
                         f.write(fp.read())
-            os.remove(gzipfile)
+            os.remove(archive_file)
             os.chmod(serverfile, 0o744)
             with open(os.path.join(cls.basedir(), "VERSION"), "w") as fp:
                 fp.write(version)

--- a/plugin.py
+++ b/plugin.py
@@ -171,7 +171,7 @@ class RustAnalyzer(AbstractPlugin):
 
             if is_windows:
                 with zipfile.ZipFile(archive_file, "r") as zip_ref:
-                    zip_ref.extract("rust-analyzer.exe", cls.basedir())
+                    zip_ref.extract(rust_analyzer_filename, cls.basedir())
             else:
                 with gzip.open(archive_file, "rb") as fp:
                     with open(rust_analyzer_path, "wb") as f:

--- a/plugin.py
+++ b/plugin.py
@@ -163,10 +163,8 @@ class RustAnalyzer(AbstractPlugin):
             extension = "zip" if is_windows else "gz"
             url = URL.format(tag=TAG, arch=arch(), platform=platform(), ext=extension)
             archive_file = os.path.join(cls.basedir(), f"rust-analyzer.{extension}")
-            serverfile = os.path.join(
-                cls.basedir(),
-                "rust-analyzer.exe" if is_windows else "rust-analyzer"
-            )
+            rust_analyzer_filename = "rust-analyzer.exe" if is_windows else "rust-analyzer"
+            rust_analyzer_path = os.path.join(cls.basedir(), rust_analyzer_filename)
             with urllib.request.urlopen(url) as fp:
                 with open(archive_file, "wb") as f:
                     f.write(fp.read())
@@ -176,10 +174,10 @@ class RustAnalyzer(AbstractPlugin):
                     zip_ref.extract("rust-analyzer.exe", cls.basedir())
             else:
                 with gzip.open(archive_file, "rb") as fp:
-                    with open(serverfile, "wb") as f:
+                    with open(rust_analyzer_path, "wb") as f:
                         f.write(fp.read())
             os.remove(archive_file)
-            os.chmod(serverfile, 0o744)
+            os.chmod(rust_analyzer_path, 0o744)
             with open(os.path.join(cls.basedir(), "VERSION"), "w") as fp:
                 fp.write(version)
         except BaseException:


### PR DESCRIPTION
* Closes #144.

This downloads and extracts `rust-analyzer.exe` to the `C:\Users\%user%\AppData\Local\Sublime Text\Package Storage\LSP-rust-analyzer` folder:

![image](https://github.com/user-attachments/assets/e31d11ee-c069-47ca-922d-94b8154e491f)
