### PR TITLE
Re-enable pull diagnostics

### DIFF
--- a/LSP-rust-analyzer.sublime-settings
+++ b/LSP-rust-analyzer.sublime-settings
@@ -245,8 +245,4 @@
 	"command": [
 		"${storage_path}/LSP-rust-analyzer/rust-analyzer"
 	],
-	"disabled_capabilities": {
-		// Workaround for https://github.com/sublimelsp/LSP/issues/2572
-		"diagnosticProvider": true,
-	}
 }


### PR DESCRIPTION
On editing a file, rust-analyzer provides diagnostics through pull diagnostics so we have to enable those.

Still things are not perfect since I see that with server closed, opening a file with a syntax error doesn't show its diagnostics until file is modified. That's because our `textDocument/diagnostic` request receives empty response and the `publishDiagnostics` notification is not received for that file either. In VSCode it works. Not sure why but they have a bunch of custom code in its vscode extension that could contributing. I can tell that `textDocument/didOpen` is triggered quite late in their case, after server have sent many requests and notifications.

Related issue #148

Fixes #163