### PR TITLE
refactor: add ruff rules for sorting imports

### DIFF
--- a/plugin.py
+++ b/plugin.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 from functools import partial
 from LSP.plugin import AbstractPlugin
 from LSP.plugin import LspTextCommand
@@ -12,7 +13,9 @@ from LSP.plugin.core.views import point_to_offset
 from LSP.plugin.core.views import region_to_range
 from LSP.plugin.core.views import text_document_position_params
 from LSP.plugin.locationpicker import LocationPicker
-from typing import Any, TypedDict, TYPE_CHECKING
+from typing import Any
+from typing import TYPE_CHECKING
+from typing import TypedDict
 import gzip
 import os
 import shutil
@@ -21,8 +24,10 @@ import urllib.request
 import zipfile
 
 if TYPE_CHECKING:
-    from collections.abc import Mapping, Callable
-    from LSP.protocol import HoverParams, Location
+    from collections.abc import Callable
+    from collections.abc import Mapping
+    from LSP.protocol import HoverParams
+    from LSP.protocol import Location
 
 
 try:

--- a/plugin_commands.py
+++ b/plugin_commands.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 from .plugin import RustAnalyzerCommand
 from LSP.plugin import apply_text_edits
 from LSP.plugin import Request
@@ -9,7 +10,9 @@ from LSP.plugin.core.views import text_document_identifier
 from LSP.protocol import Range
 from LSP.protocol import TextDocumentIdentifier
 from LSP.protocol import TextEdit
-from typing import List, Literal, TypedDict
+from typing import List
+from typing import Literal
+from typing import TypedDict
 import sublime
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,19 @@
 [tool.ruff]
 target-version = "py38"
+line-length = 120
+
+[tool.ruff.lint]
+# Enable preview rules.
+preview = true
+select = ["F401", "I"]
+
+[tool.ruff.lint.isort]
+case-sensitive = false
+force-single-line = true
+from-first = true
+no-sections = true
+order-by-type = false
+required-imports = ["from __future__ import annotations"]
 
 [tool.pyright]
 pythonVersion = "3.8"


### PR DESCRIPTION
This is a semi-automatically created PR that adds ruff configuration for imports formatting.

It matches configuration included in the LSP package with the intention of consolidating import style across all LSP packages.

If you have strong preference to a different style, please keep the configuration but update it to your liking so that anyone working on the package does not have to guess the correct style to use. See [ruff isort settings](https://docs.astral.sh/ruff/settings/#lintisort).

(Since this PR was created semi-automatically, it might require some changes before being considered ready.)