### PR TITLE
Fix "View Syntax Tree" command

### DIFF
--- a/command_syntax_tree.py
+++ b/command_syntax_tree.py
@@ -1,0 +1,227 @@
+from __future__ import annotations
+
+from functools import partial
+from LSP.plugin import LspTextCommand
+from LSP.plugin import Promise
+from LSP.plugin import Request
+from LSP.plugin.core.tree_view import new_tree_view_sheet
+from LSP.plugin.core.tree_view import TreeDataProvider
+from LSP.plugin.core.tree_view import TreeItem
+from LSP.plugin.core.views import text_document_position_params
+from LSP.protocol import NotRequired
+from LSP.protocol import Range
+from typing import Any
+from typing import cast
+from typing import Literal
+from typing import Tuple
+from typing import TypedDict
+from typing import Union
+import json
+import sublime
+import sublime_plugin
+
+
+class Offsets(TypedDict):
+    start: int
+    end: int
+
+class InnerNode(TypedDict):
+    range: Range
+    offsets: Offsets
+
+class SyntaxNode(TypedDict):
+    type: Literal['Node']
+    kind: str
+    offsets: Offsets
+    range: Range
+    # This element's position within a Rust string literal, if it's inside of one.
+    inner: InnerNode | None
+    parent: SyntaxElement | None
+    children: list[SyntaxElement]
+
+class SyntaxToken(TypedDict):
+    type: Literal['Token']
+    kind: str
+    range: Range
+    offsets: Offsets
+    # This element's position within a Rust string literal, if it's inside of one.
+    inner: InnerNode | None
+    parent: SyntaxElement | None
+
+SyntaxElement = Union[SyntaxNode, SyntaxToken]
+
+class RawNode(TypedDict):
+    type: Literal['Node']
+    kind: str
+    start: Tuple[int, int, int]
+    end: Tuple[int, int, int]
+    istart: NotRequired[Tuple[int, int, int]]
+    iend: NotRequired[Tuple[int, int, int]]
+    children: list[SyntaxElement]
+
+class RawToken(TypedDict):
+    type: Literal['Token']
+    kind: str
+    start: Tuple[int, int, int]
+    end: Tuple[int, int, int]
+    istart: NotRequired[Tuple[int, int, int]]
+    iend: NotRequired[Tuple[int, int, int]]
+
+RawElement = Union[RawNode, RawToken]
+
+
+def parseSyntaxTree(value: str) -> SyntaxElement:
+
+    def object_hook(value: RawElement) -> SyntaxElement:
+        if value['type'] != 'Node' and value['type'] != 'Token':
+            # This is something other than a RawElement.
+            return value
+
+        startOffset, startLine, startCol = value['start']
+        endOffset, endLine, endCol = value['end']
+        range: Range = {
+            'start': {
+                'line': startLine,
+                'character': startCol,
+            },
+            'end': {
+                'line': endLine,
+                'character': endCol
+            }
+        }
+        offsets: Offsets = {
+            'start': startOffset,
+            'end': endOffset,
+        }
+
+        inner: InnerNode | None = None
+        if (istart := value.get('istart')) and (iend := value.get('iend')):
+            istartOffset, istartLine, istartCol = istart
+            iendOffset, iendLine, iendCol = iend
+            inner = {
+                'offsets': {
+                    'start': istartOffset,
+                    'end': iendOffset,
+                },
+                'range': {
+                    'start': {
+                        'line': istartLine,
+                        'character': istartCol
+                    },
+                    'end': {
+                        'line': iendLine,
+                        'character': iendCol
+                    }
+                }
+            }
+
+        if value['type'] == 'Node':
+            result: SyntaxNode = {
+                'type': value['type'],
+                'kind': value['kind'],
+                'offsets': offsets,
+                'range': range,
+                'inner': inner,
+                'children': value.get('children', []),
+                'parent': None,
+            }
+
+            for child in result['children']:
+                child['parent'] = result
+
+            return result
+        else:
+            return {
+                'type': value['type'],
+                'kind': value['kind'],
+                'offsets': offsets,
+                'range': range,
+                'inner': inner,
+                'parent': None,
+            }
+
+    return json.loads(value, object_hook=lambda v: object_hook(cast('RawElement', v)))
+
+
+class SyntaxTreeProvider(TreeDataProvider):
+
+    def __init__(self, root_element: SyntaxElement, view_id: int) -> None:
+        self.root_element = root_element
+        self.view_id = view_id
+
+    def get_children(self, element: SyntaxElement | None) -> Promise[list[SyntaxElement]]:
+        if element is None:
+            return Promise.resolve([self.root_element])
+        return Promise.resolve(element.get('children', []))
+
+    def get_tree_item(self, element: SyntaxElement) -> TreeItem:
+        inner = element.get('inner', {})
+        offsets = inner['offsets'] if inner else element['offsets']
+        offsets_text = f'{offsets["start"]}..{offsets["end"]}'
+        return TreeItem(
+            label=f'{element["kind"]}',
+            description=f'({element["type"]} - {offsets_text})',
+            action_command=('rust_analyzer_syntax_tree_click_node', {
+                'view_id': self.view_id,
+                'range': element['range'],
+            })
+        )
+
+
+class RustAnalyzerSyntaxTreeCommand(LspTextCommand):
+
+    def is_enabled(self) -> bool:
+        selection = self.view.sel()
+        if len(selection) == 0:
+            return False
+        return super().is_enabled()
+
+    def run(self, edit: sublime.Edit) -> None:
+        session = self.session_by_name(self.session_name)
+        if session is None:
+            return
+        params = text_document_position_params(self.view, self.view.sel()[0].b)
+        session.send_request(
+            Request("rust-analyzer/viewSyntaxTree", params),
+            lambda response: sublime.set_timeout(partial(self.on_result, response))
+        )
+
+    def on_result(self, out: str) -> None:
+        session = self.session_by_name(self.session_name)
+        if session is None:
+            return
+        window = self.view.window()
+        if window is None:
+            return
+        sheet_name = 'Syntax Tree'
+        root_element = parseSyntaxTree(out)
+        data_provider = SyntaxTreeProvider(root_element, self.view.id())
+        new_tree_view_sheet(window, sheet_name, data_provider, sheet_name, flags=sublime.NewFileFlags.ADD_TO_SELECTION)
+
+
+class RustAnalyzerSyntaxTreeClickNode(sublime_plugin.WindowCommand):
+
+    def run(self, view_id: int, range: Range) -> None:
+        if view := self.find_view_id(view_id):
+            view.run_command('rust_analyzer_syntax_tree_select_node_in_view', {'range': cast('dict[str, Any]', range)})
+
+    def find_view_id(self, view_id) -> sublime.View | None:
+        for view in self.window.views():
+            if view.id() == view_id:
+                return view
+        return None
+
+
+class RustAnalyzerSyntaxTreeSelectNodeInView(LspTextCommand):
+
+    def run(self, _: sublime.Edit, *, range: Range) -> None:
+        view = self.view
+        selection = view.sel()
+        selection.clear()
+        start = range['start']
+        end = range['end']
+        region = sublime.Region(view.text_point_utf16(start['line'], start['character']),
+                                view.text_point_utf16(end['line'], end['character']),)
+        selection.add(region)
+        view.show_at_center(region)
+

--- a/plugin.py
+++ b/plugin.py
@@ -11,31 +11,21 @@ from LSP.plugin import Promise
 from LSP.plugin import Request
 from LSP.plugin import ServerResponse
 from LSP.plugin.core.protocol import Point
-from LSP.plugin.core.tree_view import new_tree_view_sheet
-from LSP.plugin.core.tree_view import TreeDataProvider
-from LSP.plugin.core.tree_view import TreeItem
 from LSP.plugin.core.views import first_selection_region
 from LSP.plugin.core.views import point_to_offset
 from LSP.plugin.core.views import region_to_range
-from LSP.plugin.core.views import sublime_plugin
 from LSP.plugin.core.views import text_document_position_params
 from LSP.protocol import AnnotatedTextEdit
 from LSP.protocol import InsertTextFormat
 from LSP.protocol import LSPAny
-from LSP.protocol import NotRequired
-from LSP.protocol import Range
 from LSP.protocol import SnippetTextEdit
 from LSP.protocol import TextEdit
 from typing import Any
 from typing import cast
-from typing import Literal
-from typing import Tuple
 from typing import TYPE_CHECKING
 from typing import TypedDict
-from typing import Union
 from typing_extensions import override
 import gzip
-import json
 import shutil
 import sublime
 import urllib.request
@@ -360,215 +350,6 @@ class RustAnalyzerOpenCargoToml(LspTextCommand):
         if session is None:
             return
         session.open_location_async(payload)
-
-
-class RustAnalyzerSyntaxTree(LspTextCommand):
-
-    def is_enabled(self) -> bool:
-        selection = self.view.sel()
-        if len(selection) == 0:
-            return False
-        return super().is_enabled()
-
-    def run(self, edit: sublime.Edit) -> None:
-        session = self.session_by_name(self.session_name)
-        if session is None:
-            return
-        params = text_document_position_params(self.view, self.view.sel()[0].b)
-        session.send_request(
-            Request("rust-analyzer/viewSyntaxTree", params),
-            lambda response: sublime.set_timeout(partial(self.on_result, response))
-        )
-
-    def on_result(self, out: str) -> None:
-        session = self.session_by_name(self.session_name)
-        if session is None:
-            return
-        window = self.view.window()
-        if window is None:
-            return
-        sheet_name = 'Syntax Tree'
-        root_element = parseSyntaxTree(out)
-        data_provider = SyntaxTreeProvider(root_element, self.view.id())
-        new_tree_view_sheet(window, sheet_name, data_provider, sheet_name, flags=sublime.NewFileFlags.ADD_TO_SELECTION)
-
-
-def parseSyntaxTree(value: str) -> SyntaxElement:
-
-    def object_hook(value: RawElement) -> SyntaxElement:
-        if value['type'] != 'Node' and value['type'] != 'Token':
-            # This is something other than a RawElement.
-            return value
-
-        startOffset, startLine, startCol = value['start']
-        endOffset, endLine, endCol = value['end']
-        range: Range = {
-            'start': {
-                'line': startLine,
-                'character': startCol,
-            },
-            'end': {
-                'line': endLine,
-                'character': endCol
-            }
-        }
-        offsets: Offsets = {
-            'start': startOffset,
-            'end': endOffset,
-        }
-
-        inner: InnerNode | None = None
-        if (istart := value.get('istart')) and (iend := value.get('iend')):
-            istartOffset, istartLine, istartCol = istart
-            iendOffset, iendLine, iendCol = iend
-            inner = {
-                'offsets': {
-                    'start': istartOffset,
-                    'end': iendOffset,
-                },
-                'range': {
-                    'start': {
-                        'line': istartLine,
-                        'character': istartCol
-                    },
-                    'end': {
-                        'line': iendLine,
-                        'character': iendCol
-                    }
-                }
-            }
-
-        if value['type'] == 'Node':
-            result: SyntaxNode = {
-                'type': value['type'],
-                'kind': value['kind'],
-                'offsets': offsets,
-                'range': range,
-                'inner': inner,
-                'children': value.get('children', []),
-                'parent': None,
-            }
-
-            for child in result['children']:
-                child['parent'] = result
-
-            return result
-        else:
-            return {
-                'type': value['type'],
-                'kind': value['kind'],
-                'offsets': offsets,
-                'range': range,
-                'inner': inner,
-                'parent': None,
-            }
-
-    return json.loads(value, object_hook=lambda v: object_hook(cast('RawElement', v)))
-
-
-class Offsets(TypedDict):
-    start: int
-    end: int
-
-
-class InnerNode(TypedDict):
-    range: Range
-    offsets: Offsets
-
-
-class SyntaxNode(TypedDict):
-    type: Literal['Node']
-    kind: str
-    offsets: Offsets
-    range: Range
-    # This element's position within a Rust string literal, if it's inside of one.
-    inner: InnerNode | None
-    parent: SyntaxElement | None
-    children: list[SyntaxElement]
-
-class SyntaxToken(TypedDict):
-    type: Literal['Token']
-    kind: str
-    range: Range
-    offsets: Offsets
-    # This element's position within a Rust string literal, if it's inside of one.
-    inner: InnerNode | None
-    parent: SyntaxElement | None
-
-SyntaxElement = Union[SyntaxNode, SyntaxToken]
-
-
-class RawNode(TypedDict):
-    type: Literal['Node']
-    kind: str
-    start: Tuple[int, int, int]
-    end: Tuple[int, int, int]
-    istart: NotRequired[Tuple[int, int, int]]
-    iend: NotRequired[Tuple[int, int, int]]
-    children: list[SyntaxElement]
-
-class RawToken(TypedDict):
-    type: Literal['Token']
-    kind: str
-    start: Tuple[int, int, int]
-    end: Tuple[int, int, int]
-    istart: NotRequired[Tuple[int, int, int]]
-    iend: NotRequired[Tuple[int, int, int]]
-
-RawElement = Union[RawNode, RawToken]
-
-
-class SyntaxTreeProvider(TreeDataProvider):
-
-    def __init__(self, root_element: SyntaxElement, view_id: int) -> None:
-        self.root_element = root_element
-        self.view_id = view_id
-
-    def get_children(self, element: SyntaxElement | None) -> Promise[list[SyntaxElement]]:
-        if element is None:
-            return Promise.resolve([self.root_element])
-        return Promise.resolve(element.get('children', []))
-
-    def get_tree_item(self, element: SyntaxElement) -> TreeItem:
-        label = f'{element["kind"]}'
-        range_text = f'{element["offsets"]["start"]}..{element["offsets"]["end"]}'
-        description = f'({element["type"]} - {range_text})'
-        return TreeItem(
-            label,
-            description=description,
-            action_command=('rust_analyzer_click_syntax_node', {
-                'view_id': self.view_id,
-                'range': element['range'],
-            })
-        )
-
-
-
-class RustAnalyzerClickSyntaxNode(sublime_plugin.WindowCommand):
-
-    def run(self, view_id: int, range: Range) -> None:
-        if view := self.find_view_id(view_id):
-            view.run_command('rust_analyzer_select_syntax_node_in_view', {'range': range})
-
-    def find_view_id(self, view_id) -> sublime.View | None:
-        for view in self.window.views():
-            if view.id() == view_id:
-                return view
-        return None
-
-
-class RustAnalyzerSelectSyntaxNodeInView(LspTextCommand):
-
-    def run(self, _: sublime.Edit, *, range: Range) -> None:
-        view = self.view
-        selection = view.sel()
-        selection.clear()
-        start = range['start']
-        end = range['end']
-        region = sublime.Region(view.text_point_utf16(start['line'], start['character']),
-                                view.text_point_utf16(end['line'], end['character']),)
-        selection.add(region)
-        view.show_at_center(region)
 
 
 class RustAnalyzerViewItemTree(LspTextCommand):

--- a/plugin.py
+++ b/plugin.py
@@ -11,21 +11,31 @@ from LSP.plugin import Promise
 from LSP.plugin import Request
 from LSP.plugin import ServerResponse
 from LSP.plugin.core.protocol import Point
+from LSP.plugin.core.tree_view import new_tree_view_sheet
+from LSP.plugin.core.tree_view import TreeDataProvider
+from LSP.plugin.core.tree_view import TreeItem
 from LSP.plugin.core.views import first_selection_region
 from LSP.plugin.core.views import point_to_offset
 from LSP.plugin.core.views import region_to_range
+from LSP.plugin.core.views import sublime_plugin
 from LSP.plugin.core.views import text_document_position_params
 from LSP.protocol import AnnotatedTextEdit
 from LSP.protocol import InsertTextFormat
 from LSP.protocol import LSPAny
+from LSP.protocol import NotRequired
+from LSP.protocol import Range
 from LSP.protocol import SnippetTextEdit
 from LSP.protocol import TextEdit
 from typing import Any
 from typing import cast
+from typing import Literal
+from typing import Tuple
 from typing import TYPE_CHECKING
 from typing import TypedDict
+from typing import Union
 from typing_extensions import override
 import gzip
+import json
 import shutil
 import sublime
 import urllib.request
@@ -199,7 +209,7 @@ class RustAnalyzer(LspPlugin):
             return
 
     def convert_proprietary_snippet(self, edit: TextEdit | AnnotatedTextEdit) -> None:
-        if not 'snippet' in edit and edit.get('insertTextFormat') == InsertTextFormat.Snippet:
+        if edit.get('insertTextFormat') == InsertTextFormat.Snippet:
             cast('SnippetTextEdit', edit)['snippet'] = {'kind': 'snippet', 'value': edit['newText']}
 
 
@@ -361,32 +371,204 @@ class RustAnalyzerSyntaxTree(LspTextCommand):
         return super().is_enabled()
 
     def run(self, edit: sublime.Edit) -> None:
-        params = text_document_position_params(self.view, self.view.sel()[0].b)
         session = self.session_by_name(self.session_name)
         if session is None:
             return
+        params = text_document_position_params(self.view, self.view.sel()[0].b)
         session.send_request(
-            Request("rust-analyzer/syntaxTree", params),
+            Request("rust-analyzer/viewSyntaxTree", params),
             lambda response: sublime.set_timeout(partial(self.on_result, response))
         )
 
-    def on_result(self, out: str | None) -> None:
+    def on_result(self, out: str) -> None:
+        session = self.session_by_name(self.session_name)
+        if session is None:
+            return
         window = self.view.window()
         if window is None:
             return
-        if out is None:
-            return
-        sheets = window.selected_sheets()
-        view = window.new_file(flags=sublime.TRANSIENT)
-        view.set_scratch(True)
-        view.set_name("Syntax Tree")
-        # Resource Aware Session Types Syntax highlighting not available
-        view.run_command("append", {"characters": out})
-        view.set_read_only(True)
-        sheet = view.sheet()
-        if sheet is not None:
-            sheets.append(sheet)
-            window.select_sheets(sheets)
+        sheet_name = 'Syntax Tree'
+        root_element = parseSyntaxTree(out)
+        data_provider = SyntaxTreeProvider(root_element, self.view.id())
+        new_tree_view_sheet(window, sheet_name, data_provider, sheet_name, flags=sublime.NewFileFlags.ADD_TO_SELECTION)
+
+
+def parseSyntaxTree(value: str) -> SyntaxElement:
+
+    def object_hook(value: RawElement) -> SyntaxElement:
+        if value['type'] != 'Node' and value['type'] != 'Token':
+            # This is something other than a RawElement.
+            return value
+
+        startOffset, startLine, startCol = value['start']
+        endOffset, endLine, endCol = value['end']
+        range: Range = {
+            'start': {
+                'line': startLine,
+                'character': startCol,
+            },
+            'end': {
+                'line': endLine,
+                'character': endCol
+            }
+        }
+        offsets: Offsets = {
+            'start': startOffset,
+            'end': endOffset,
+        }
+
+        inner: InnerNode | None = None
+        if (istart := value.get('istart')) and (iend := value.get('iend')):
+            istartOffset, istartLine, istartCol = istart
+            iendOffset, iendLine, iendCol = iend
+            inner = {
+                'offsets': {
+                    'start': istartOffset,
+                    'end': iendOffset,
+                },
+                'range': {
+                    'start': {
+                        'line': istartLine,
+                        'character': istartCol
+                    },
+                    'end': {
+                        'line': iendLine,
+                        'character': iendCol
+                    }
+                }
+            }
+
+        if value['type'] == 'Node':
+            result: SyntaxNode = {
+                'type': value['type'],
+                'kind': value['kind'],
+                'offsets': offsets,
+                'range': range,
+                'inner': inner,
+                'children': value.get('children', []),
+                'parent': None,
+            }
+
+            for child in result['children']:
+                child['parent'] = result
+
+            return result
+        else:
+            return {
+                'type': value['type'],
+                'kind': value['kind'],
+                'offsets': offsets,
+                'range': range,
+                'inner': inner,
+                'parent': None,
+            }
+
+    return json.loads(value, object_hook=lambda v: object_hook(cast('RawElement', v)))
+
+
+class Offsets(TypedDict):
+    start: int
+    end: int
+
+
+class InnerNode(TypedDict):
+    range: Range
+    offsets: Offsets
+
+
+class SyntaxNode(TypedDict):
+    type: Literal['Node']
+    kind: str
+    offsets: Offsets
+    range: Range
+    # This element's position within a Rust string literal, if it's inside of one.
+    inner: InnerNode | None
+    parent: SyntaxElement | None
+    children: list[SyntaxElement]
+
+class SyntaxToken(TypedDict):
+    type: Literal['Token']
+    kind: str
+    range: Range
+    offsets: Offsets
+    # This element's position within a Rust string literal, if it's inside of one.
+    inner: InnerNode | None
+    parent: SyntaxElement | None
+
+SyntaxElement = Union[SyntaxNode, SyntaxToken]
+
+
+class RawNode(TypedDict):
+    type: Literal['Node']
+    kind: str
+    start: Tuple[int, int, int]
+    end: Tuple[int, int, int]
+    istart: NotRequired[Tuple[int, int, int]]
+    iend: NotRequired[Tuple[int, int, int]]
+    children: list[SyntaxElement]
+
+class RawToken(TypedDict):
+    type: Literal['Token']
+    kind: str
+    start: Tuple[int, int, int]
+    end: Tuple[int, int, int]
+    istart: NotRequired[Tuple[int, int, int]]
+    iend: NotRequired[Tuple[int, int, int]]
+
+RawElement = Union[RawNode, RawToken]
+
+
+class SyntaxTreeProvider(TreeDataProvider):
+
+    def __init__(self, root_element: SyntaxElement, view_id: int) -> None:
+        self.root_element = root_element
+        self.view_id = view_id
+
+    def get_children(self, element: SyntaxElement | None) -> Promise[list[SyntaxElement]]:
+        if element is None:
+            return Promise.resolve([self.root_element])
+        return Promise.resolve(element.get('children', []))
+
+    def get_tree_item(self, element: SyntaxElement) -> TreeItem:
+        label = f'{element["kind"]}'
+        range_text = f'{element["offsets"]["start"]}..{element["offsets"]["end"]}'
+        description = f'({element["type"]} - {range_text})'
+        return TreeItem(
+            label,
+            description=description,
+            action_command=('rust_analyzer_click_syntax_node', {
+                'view_id': self.view_id,
+                'range': element['range'],
+            })
+        )
+
+
+
+class RustAnalyzerClickSyntaxNode(sublime_plugin.WindowCommand):
+
+    def run(self, view_id: int, range: Range) -> None:
+        if view := self.find_view_id(view_id):
+            view.run_command('rust_analyzer_select_syntax_node_in_view', {'range': range})
+
+    def find_view_id(self, view_id) -> sublime.View | None:
+        for view in self.window.views():
+            if view.id() == view_id:
+                return view
+        return None
+
+
+class RustAnalyzerSelectSyntaxNodeInView(LspTextCommand):
+
+    def run(self, _: sublime.Edit, *, range: Range) -> None:
+        view = self.view
+        selection = view.sel()
+        selection.clear()
+        start = range['start']
+        end = range['end']
+        region = sublime.Region(view.text_point_utf16(start['line'], start['character']),
+                                view.text_point_utf16(end['line'], end['character']),)
+        selection.add(region)
+        view.show_at_center(region)
 
 
 class RustAnalyzerViewItemTree(LspTextCommand):


### PR DESCRIPTION
I think I went a bit overboard and implemented syntax tree view with clickable nodes.

Fixes #222 

<img width="940" height="348" alt="Screenshot 2026-07-03 at 17 37 01" src="https://github.com/user-attachments/assets/3630a857-ed76-4533-986a-f80c153e3493" />
